### PR TITLE
Remove shallowEqual module, simply require 'shallowequal' directly

### DIFF
--- a/src/PureRenderMixin.js
+++ b/src/PureRenderMixin.js
@@ -1,4 +1,4 @@
-const shallowEqual = require('./shallowEqual');
+const shallowEqual = require('shallowequal');
 
 /**
  * If your React component's render function is "pure", e.g. it will render the

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ module.exports = {
   joinClasses: require('./joinClasses'),
   KeyCode: require('./KeyCode'),
   PureRenderMixin: require('./PureRenderMixin'),
-  shallowEqual: require('./shallowEqual'),
+  shallowEqual: require('shallowequal'),
   createChainedFunction: require('./createChainedFunction'),
   Dom: {
     addEventListener: require('./Dom/addEventListener'),

--- a/src/shallowEqual.js
+++ b/src/shallowEqual.js
@@ -1,3 +1,0 @@
-const shallowEqual = require('shallowequal');
-
-module.exports = shallowEqual;


### PR DESCRIPTION
Fixes webpack case error:

```
WARNING in ./~/rc-util/lib/shallowEqual.js
There is another module with an equal name when case is ignored.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
Rename module if multiple modules are expected or use equal casing if one module is expected.

WARNING in ./~/rc-util/lib/shallowequal.js
There is another module with an equal name when case is ignored.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
Rename module if multiple modules are expected or use equal casing if one module is expected.
```

This error is wrong, but there's no reason for the module to exist anyway. This won't break backcompat.