### PR TITLE
Revert PureRenderMixin

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lint"
   ],
   "dependencies": {
-    "add-dom-event-listener": "1.x"
+    "add-dom-event-listener": "1.x",
+    "shallowequal": "^0.2.2"
   }
 }

--- a/src/PureRenderMixin.js
+++ b/src/PureRenderMixin.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactComponentWithPureRenderMixin
+ */
+
+const shallowEqual = require('shallowequal');
+
+function shallowCompare(instance, nextProps, nextState) {
+  return !shallowEqual(instance.props, nextProps) || !shallowEqual(instance.state, nextState);
+}
+
+/**
+ * If your React component's render function is "pure", e.g. it will render the
+ * same result given the same props and state, provide this mixin for a
+ * considerable performance boost.
+ *
+ * Most React components have pure render functions.
+ *
+ * Example:
+ *
+ *   var ReactComponentWithPureRenderMixin =
+ *     require('ReactComponentWithPureRenderMixin');
+ *   React.createClass({
+ *     mixins: [ReactComponentWithPureRenderMixin],
+ *
+ *     render: function() {
+ *       return <div className={this.props.className}>foo</div>;
+ *     }
+ *   });
+ *
+ * Note: This only checks shallow equality for props and state. If these contain
+ * complex data structures this mixin may have false-negatives for deeper
+ * differences. Only mixin to components which have simple props and state, or
+ * use `forceUpdate()` when you know deep data structures have changed.
+ *
+ * See https://facebook.github.io/react/docs/pure-render-mixin.html
+ */
+const ReactComponentWithPureRenderMixin = {
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  },
+};
+
+module.exports = ReactComponentWithPureRenderMixin;

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,8 +1,11 @@
 const expect = require('expect.js');
 const createChainedFunction = require('../src/createChainedFunction');
+const PureRenderMixin = require('../src/PureRenderMixin');
+const React = require('react');
+const ReactDOM = require('react-dom');
 
-describe('createChainedFunction', () => {
-  it('should work', () => {
+describe('rc-util', () => {
+  it('createChainedFunction works', () => {
     const ret = [];
 
     function f1() {
@@ -19,5 +22,28 @@ describe('createChainedFunction', () => {
 
     createChainedFunction(f1, f2, f3, null)();
     expect(ret).to.eql([1, 2, 3]);
+  });
+
+  it('PureRenderMixin works', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    let count = 0;
+    const C = React.createClass({
+      mixins: [PureRenderMixin],
+      getInitialState() {
+        return {
+          a: 1,
+        };
+      },
+      render() {
+        count++;
+        return <span>{this.state.a}</span>;
+      },
+    });
+    const c = ReactDOM.render(<C />, div);
+    c.setState({
+      a: 1,
+    });
+    expect(count).to.be(1);
   });
 });


### PR DESCRIPTION
根据 https://github.com/ant-design/ant-design/issues/3338 的讨论，把 PureRenderMixin 加回来，然后去掉了里面的 warning。