### PR TITLE
Add entry points for ES5 and ES6 folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "lib",
     "es"
   ],
+  "main": "./lib",
+  "module": "./es",
   "homepage": "http://github.com/react-component/util",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

On our application we are using [rc-slider](https://github.com/react-component/slider) which has a dependency on [rc-util](https://github.com/react-component/util)

## Issue

When building we had this error reported:

```
/Users/david.lampon/Projects/jobs/client/node_modules/rc-util/es/Dom/addEventListener.js:1
(function (exports, require, module, __filename, __dirname) { import addDOMEventListener from 'add-dom-event-listener';
                                                              ^^^^^^

SyntaxError: Unexpected token import
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:599:28)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Module.require (module.js:579:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/david.lampon/Projects/jobs/client/node_modules/.cache/hops/server.js:11446:18)
    at __webpack_require__ (/Users/david.lampon/Projects/jobs/client/node_modules/.cache/hops/server.js:21:30)
    at Object.<anonymous> (/Users/david.lampon/Projects/jobs/client/node_modules/.cache/hops/server.js:36287:90)
    at __webpack_require__ (/Users/david.lampon/Projects/jobs/client/node_modules/.cache/hops/server.js:21:30)
    at Object.<anonymous> (/Users/david.lampon/Projects/jobs/client/node_modules/.cache/hops/server.js:83909:79)
    at __webpack_require__ (/Users/david.lampon/Projects/jobs/client/node_modules/.cache/hops/server.js:21:30)
    at Object.<anonymous> (/Users/david.lampon/Projects/jobs/client/node_modules/.cache/hops/server.js:36214:66)
```

## Solution

Add two entry points in the package.json to properly point to the original and transpiled folders that were missing.