### PR TITLE
Make react-dom a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,11 +51,13 @@
   "pre-commit": [
     "lint"
   ],
+  "peerDependencies": {
+    "react-dom": "^16.2.0"
+  },
   "dependencies": {
     "add-dom-event-listener": "1.x",
     "babel-runtime": "6.x",
     "prop-types": "^15.5.10",
-    "shallowequal": "^0.2.2",
-    "react-dom": "^16.2.0"
+    "shallowequal": "^0.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "jest": "20.x",
     "pre-commit": "^1.0.7",
     "rc-tools": "6.x",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react": "^16.2.0"
   },
   "pre-commit": [
     "lint"
@@ -56,6 +55,7 @@
     "add-dom-event-listener": "1.x",
     "babel-runtime": "6.x",
     "prop-types": "^15.5.10",
-    "shallowequal": "^0.2.2"
+    "shallowequal": "^0.2.2",
+    "react-dom": "^16.2.0"
   }
 }


### PR DESCRIPTION
This package [has an actual dependency](https://github.com/react-component/util/blob/6a7c079e2b86a7bb93578db54650d8ed0a4da586/src/Dom/addEventListener.js#L2) on `react-dom`, but only states it as a devDependency. This is missed by tests, but (obviously) breaks all sorts of things in production.