### PR TITLE
feat: Support `composeRef`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
   - yiminghe@gmail.com
 
 node_js:
-- 4.0.0
+- 10.0.0
 
 before_install:
 - |

--- a/src/ref.ts
+++ b/src/ref.ts
@@ -1,0 +1,22 @@
+/* eslint-disable no-param-reassign */
+import React from 'react';
+
+export function fillRef<T>(ref: React.Ref<T>, node: T) {
+  if (typeof ref === 'function') {
+    ref(node);
+  } else if (typeof ref === 'object' && ref && 'current' in ref) {
+    (ref as any).current = node;
+  }
+}
+
+/**
+ * Merge refs into one ref function to support ref passing.
+ */
+export function composeRef<T>(...refs: React.Ref<T>[]): React.Ref<T> {
+  return (node: T) => {
+    refs.forEach(ref => {
+      fillRef(ref, node);
+    });
+  };
+}
+/* eslint-enable */

--- a/tests/ref.test.js
+++ b/tests/ref.test.js
@@ -1,0 +1,14 @@
+import { composeRef } from '../src/ref';
+
+describe('ref', () => {
+  it('composeRef', () => {
+    const refFunc1 = jest.fn();
+    const refFunc2 = jest.fn();
+
+    const mergedRef = composeRef(refFunc1, refFunc2);
+    const testRefObj = {};
+    mergedRef(testRefObj);
+    expect(refFunc1).toHaveBeenCalledWith(testRefObj);
+    expect(refFunc2).toHaveBeenCalledWith(testRefObj);
+  });
+});


### PR DESCRIPTION
Too many place for compose ref since remove `findDOMNode` remove. Move the code into `rc-util` instead.