### PR TITLE
Remove unused/ unnecessary babel-runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "dependencies": {
     "add-dom-event-listener": "^1.1.0",
-    "babel-runtime": "6.x",
     "prop-types": "^15.5.10",
     "react-lifecycles-compat": "^3.0.4",
     "shallowequal": "^1.1.0"


### PR DESCRIPTION
Similar fix to: https://github.com/react-component/drawer/pull/121

Noticed this problem when I saw `core-js` `2.x` being included in a dependency tree for an application I work on:

```
yarn why core-js
yarn why v1.16.0
[1/4] Why do we have the module "core-js"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "core-js@3.6.4"
info Has been hoisted to "core-js"
info Reasons this module exists
   - Hoisted from "@babel#node#core-js"
   - Hoisted from "recharts#core-js"
   - Hoisted from "react-scripts#react-app-polyfill#core-js"
info Disk size without dependencies: "7.13MB"
info Disk size with unique dependencies: "7.13MB"
info Disk size with transitive dependencies: "7.13MB"
info Number of shared dependencies: 0
=> Found "babel-runtime#core-js@2.6.11"
info This module exists because "rc-drawer#rc-util#babel-runtime" depends on it.
info Disk size without dependencies: "7.68MB"
info Disk size with unique dependencies: "7.68MB"
info Disk size with transitive dependencies: "7.68MB"
info Number of shared dependencies: 0
```