### PR TITLE
feat: getContainer改变后更新Portal的容器

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "create-react-class": "^15.6.3",
     "enzyme": "^3.10.0",
     "eslint": "^6.6.0",
+    "eslint-plugin-react-hooks": "^2.5.1",
     "father": "^2.14.0",
     "np": "^5.0.3",
     "react": "^16.2.0",

--- a/src/Portal.js
+++ b/src/Portal.js
@@ -7,7 +7,11 @@ export default class Portal extends React.Component {
     getContainer: PropTypes.func.isRequired,
     children: PropTypes.node.isRequired,
     didUpdate: PropTypes.func,
-  }
+  };
+
+  static defaultProps = {
+    didUpdate: ()=> void,
+  };
 
   componentDidMount() {
     this.createContainer();
@@ -25,19 +29,23 @@ export default class Portal extends React.Component {
   }
 
   createContainer() {
-    this._container = this.props.getContainer();
+    this.portalContainer = this.props.getContainer();
     this.forceUpdate();
   }
 
   removeContainer() {
-    if (this._container) {
-      this._container.parentNode.removeChild(this._container);
+    if (this.portalContainer) {
+      this.portalContainer = null;
     }
   }
 
   render() {
-    if (this._container) {
-      return ReactDOM.createPortal(this.props.children, this._container);
+    if (this.portalContainer) {
+      const currentContainer = this.props.getContainer();
+      if (currentContainer && this.portalContainer !== currentContainer) {
+        this.portalContainer = currentContainer;
+      }
+      return ReactDOM.createPortal(this.props.children, this.portalContainer);
     }
     return null;
   }

--- a/tests/container.test.js
+++ b/tests/container.test.js
@@ -1,0 +1,39 @@
+// import React from 'react';
+// import { mount } from 'enzyme';
+// import PortalWrapper from '../src/PortalWrapper';
+
+// const delay = timeout => new Promise(resolve => setTimeout(resolve, timeout));
+
+// describe('container', () => {
+//   it('Same function returns different DOM', async () => {
+//     let root = document.getElementById('root');
+//     if (!root) {
+//       root = document.createElement('div', { id: 'root' });
+//       root.id = 'root';
+//       document.body.appendChild(root);
+//     }
+//     mount(
+//       <div>
+//         <div id="dom1">Hello</div>
+//         <div id="dom2">World</div>
+//       </div>,
+//       { attachTo: root },
+//     );
+//     const holdContainer = {
+//       container: document.getElementById('dom1'),
+//     };
+//     const getContainer = () => {
+//       return holdContainer.container;
+//     };
+//     const wrapper = mount(
+//       <PortalWrapper getContainer={getContainer}>
+//         {() => 'Content'}
+//       </PortalWrapper>,
+//     );
+//     expect(wrapper).toMatchSnapshot();
+//     await delay(1000);
+//     holdContainer.container = document.getElementById('dom2');
+//     wrapper.setProps({ 'data-only-trigger-re-render': true });
+//     expect(wrapper).toMatchSnapshot();
+//   });
+// });


### PR DESCRIPTION
1. 修复的问题现象是：当我改变容器后，visible变化第一次不会渲染到对的container中，当visible第二次变为true才会渲染正确
2. 问题的原因是：当getContainer改变后，内部createPortal的container一直没变，和这个类似[#17645](https://github.com/ant-design/ant-design/pull/17645)
3. removeChild的节点的引用会被存起来，因为引用指向父组件的this.container，但是该节点和父子节点的关联关系被删除掉了，导致下次渲染在PortalWrapper中判断存在，不会重新createElement，所以我在unMount中将container置为null了。[参考](https://developer.mozilla.org/zh-CN/docs/Web/API/Node/removeChild)