### PR TITLE
Dedup babel runtime

### DIFF
--- a/.fatherrc.js
+++ b/.fatherrc.js
@@ -1,8 +1,9 @@
 export default {
   cjs: 'babel',
   esm: { type: 'babel', importLibToEs: true },
+  runtimeHelpers: true,
   preCommit: {
     eslint: true,
     prettier: true,
   },
-}
+};

--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
     "father": "^2.14.0",
     "np": "^5.0.3",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react-dom": "^16.2.0",
+    "typescript": "^3.8.3"
   },
   "dependencies": {
     "add-dom-event-listener": "^1.1.0",
-    "babel-runtime": "6.x",
     "prop-types": "^15.5.10",
     "react-is": "^16.12.0",
     "react-lifecycles-compat": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "@babel/runtime": "^7.9.2",
     "add-dom-event-listener": "^1.1.0",
     "prop-types": "^15.5.10",
     "react-is": "^16.12.0",


### PR DESCRIPTION
看了一下，几个库 babel runtime 有 inline，有 deps 的。全改成 deps，也能省一些。