### PR TITLE
fix(PortalWrapper): use wrong this

### DIFF
--- a/src/PortalWrapper.js
+++ b/src/PortalWrapper.js
@@ -51,7 +51,7 @@ class PortalWrapper extends React.Component {
         visible: prevVisible,
         getContainer: prevGetContainer,
       } = prevProps;
-      if (visible !== prevVisible && !windowIsUndefined && this.getParent() === document.body) {
+      if (visible !== prevVisible && !windowIsUndefined && _self.getParent() === document.body) {
         openCount = visible && !prevVisible ? openCount + 1 : openCount - 1;
       }
       const getContainerIsFunc =


### PR DESCRIPTION
close #116 

PortalWrapper.js 的 getDerivedStateFromProps 调用 getParent 应该使用 _self，而不是 this