### PR TITLE
Adding `exports` map and `peerDependencies` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,9 @@
   "dependencies": {
     "react-is": "^16.12.0",
     "shallowequal": "^1.1.0"
+  },
+  "peerDependencies": {
+    "react": ">= ^16.2.0",
+    "react-dom": ">= ^16.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,36 @@
     "test": "father test",
     "coverage": "father test --coverage && cat ./coverage/lcov.info | coveralls"
   },
+  "exports": {
+    "./": {
+      "import": "./es/",
+      "require": "./lib/"
+    },
+    "./Children": {
+      "import": "./es/Children/",
+      "require": "./lib/Children/"
+    },
+    "./Dom": {
+      "import": "./es/Dom/",
+      "require": "./lib/Dom/"
+    },
+    "./debug": {
+      "import": "./es/debug/",
+      "require": "./lib/debug/"
+    },
+    "./hooks": {
+      "import": "./es/hooks",
+      "require": "./lib/hooks/"
+    },
+    "./test": {
+      "import": "./es/test/",
+      "require": "./lib/test/"
+    },
+    "./utils": {
+      "import": "./es/utils/",
+      "require": "./lib/utils/"
+    }
+  },
   "devDependencies": {
     "@types/enzyme": "^3.10.5",
     "@types/jest": "^25.2.3",


### PR DESCRIPTION
Adding `exports` map and `peerDependencies` to `package.json`

Currently when we use `antd` from any `cdn` provider like `skypack` or `antd` we will run into 2 issues regarding the cdn you are using. I tried to resolve the issues in this PR. 

### Missing peerDependencies

Currently i see the package is using `react` and `react-dom` but they are defined only in `devDependencies`  alone. This doesn't raise a issue when used local, because most of the time. It will be used in a `react` based project and works. But when loaded via `cdn`'s like this. They miss out the package information and breaks instead.

### How `jspm` handles the issue

Right now, if the package is missing in `package.json` it tries to redirect to the latest version of it. 
It's just as a fallback and here it is why it can't the solution always and the package need to be corrected, for example you are using `react@16.2` in development. But it might load `react16.7` since it is the latest release. 
And that's the main reason why skypack throws error too.

### How `skypack` handles it

Skypack throws an error instead, currently it checks on `peerDependencies` and `dependencies` alone for the version number.


### Missing export map

Both the `cdn`'s highly rely on `exports` field in the `package.json` for resolving the modules which is a `node` standard for handling. Since `main` field is missing from the `package.json` and `exports` map too. It is causing issues when static analysis happens in the package.

But the `exports` introduces the change in the **way** the package is being used. For example,  `rc-image` which uses this package for adding functionalities uses like

https://github.com/react-component/image/blob/ac08b58b28a560ce2422ad43ac61a1f664f3c602/src/getFixScaleEleTransPosition.tsx#L1

```js
import raf from 'rc-util/lib/raf';
import { getClientSize } from 'rc-util/lib/Dom/css';
import addEventListener from 'rc-util/lib/Dom/addEventListener';
import { getOffset } from 'rc-util/lib/Dom/css';
```

should be changed to 

```js
import raf from 'rc-util/raf';
import { getClientSize } from 'rc-util/Dom/css';
import addEventListener from 'rc-util/Dom/addEventListener';
import { getOffset } from 'rc-util/Dom/css';
```

Since the `cjs` or `esm` resolution is taken care by export map itself.

PS: 
If the package doesn't want to introduce this change for imports, i can revert the change from the PR and add `peerDependency` change alone.