### PR TITLE
fix: StrictMode modal scroll bar

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ const config = {
     'react/no-did-update-set-state': 0,
     'react/no-find-dom-node': 0,
     'import/no-extraneous-dependencies': 0,
+    'react/sort-comp': 0,
   },
 };
 

--- a/src/PortalWrapper.tsx
+++ b/src/PortalWrapper.tsx
@@ -68,7 +68,7 @@ class PortalWrapper extends React.Component<PortalWrapperProps> {
   }) => void;
 
   componentDidMount() {
-    this.updateOpenCount({});
+    this.updateOpenCount();
 
     if (!this.attachToParent()) {
       this.rafId = raf(() => {
@@ -84,10 +84,9 @@ class PortalWrapper extends React.Component<PortalWrapperProps> {
     this.attachToParent();
   }
 
-  updateOpenCount = ({
-    visible: prevVisible,
-    getContainer: prevGetContainer,
-  }: Partial<PortalWrapperProps>) => {
+  updateOpenCount = (prevProps?: Partial<PortalWrapperProps>) => {
+    const { visible: prevVisible, getContainer: prevGetContainer } =
+      prevProps || {};
     const { visible, getContainer } = this.props;
 
     // Update count
@@ -96,7 +95,11 @@ class PortalWrapper extends React.Component<PortalWrapperProps> {
       supportDom &&
       getParent(getContainer) === document.body
     ) {
-      openCount = visible && !prevVisible ? openCount + 1 : openCount - 1;
+      if (visible && !prevVisible) {
+        openCount += 1;
+      } else if (prevProps) {
+        openCount -= 1;
+      }
     }
 
     // Clean up container if needed

--- a/src/PortalWrapper.tsx
+++ b/src/PortalWrapper.tsx
@@ -54,14 +54,7 @@ export interface PortalWrapperProps {
   }) => React.ReactNode;
 }
 
-export interface PortalWrapperState {
-  _self: PortalWrapper;
-}
-
-class PortalWrapper extends React.Component<
-  PortalWrapperProps,
-  PortalWrapperState
-> {
+class PortalWrapper extends React.Component<PortalWrapperProps> {
   container?: HTMLElement;
 
   componentRef: React.RefObject<PortalRef> = React.createRef();
@@ -74,18 +67,14 @@ class PortalWrapper extends React.Component<
     visible: boolean;
   }) => void;
 
-  constructor(props: PortalWrapperProps) {
-    super(props);
-    const { visible, getContainer } = props;
+  componentDidMount() {
+    const { visible, getContainer } = this.props;
     if (supportDom && getParent(getContainer) === document.body) {
       openCount = visible ? openCount + 1 : openCount;
     }
-    this.state = {
-      _self: this,
-    };
-  }
 
-  componentDidMount() {
+    this.updateOpenCount({});
+
     if (!this.attachToParent()) {
       this.rafId = raf(() => {
         this.forceUpdate();
@@ -93,10 +82,40 @@ class PortalWrapper extends React.Component<
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: PortalWrapperProps) {
+    this.updateOpenCount(prevProps);
+
     this.setWrapperClassName();
     this.attachToParent();
   }
+
+  updateOpenCount = ({
+    visible: prevVisible,
+    getContainer: prevGetContainer,
+  }: Partial<PortalWrapperProps>) => {
+    const { visible, getContainer } = this.props;
+
+    // Update count
+    if (
+      visible !== prevVisible &&
+      supportDom &&
+      getParent(getContainer) === document.body
+    ) {
+      openCount = visible && !prevVisible ? openCount + 1 : openCount - 1;
+    }
+
+    // Clean up container if needed
+    const getContainerIsFunc =
+      typeof getContainer === 'function' &&
+      typeof prevGetContainer === 'function';
+    if (
+      getContainerIsFunc
+        ? getContainer.toString() !== prevGetContainer.toString()
+        : getContainer !== prevGetContainer
+    ) {
+      this.removeCurrentContainer();
+    }
+  };
 
   componentWillUnmount() {
     const { visible, getContainer } = this.props;
@@ -106,36 +125,6 @@ class PortalWrapper extends React.Component<
     }
     this.removeCurrentContainer();
     raf.cancel(this.rafId);
-  }
-
-  static getDerivedStateFromProps(props, { prevProps, _self }) {
-    const { visible, getContainer } = props;
-    if (prevProps) {
-      const {
-        visible: prevVisible,
-        getContainer: prevGetContainer,
-      } = prevProps;
-      if (
-        visible !== prevVisible &&
-        supportDom &&
-        getParent(getContainer) === document.body
-      ) {
-        openCount = visible && !prevVisible ? openCount + 1 : openCount - 1;
-      }
-      const getContainerIsFunc =
-        typeof getContainer === 'function' &&
-        typeof prevGetContainer === 'function';
-      if (
-        getContainerIsFunc
-          ? getContainer.toString() !== prevGetContainer.toString()
-          : getContainer !== prevGetContainer
-      ) {
-        _self.removeCurrentContainer();
-      }
-    }
-    return {
-      prevProps: props,
-    };
   }
 
   attachToParent = (force = false) => {

--- a/src/PortalWrapper.tsx
+++ b/src/PortalWrapper.tsx
@@ -68,11 +68,6 @@ class PortalWrapper extends React.Component<PortalWrapperProps> {
   }) => void;
 
   componentDidMount() {
-    const { visible, getContainer } = this.props;
-    if (supportDom && getParent(getContainer) === document.body) {
-      openCount = visible ? openCount + 1 : openCount;
-    }
-
     this.updateOpenCount({});
 
     if (!this.attachToParent()) {

--- a/tests/Portal.test.tsx
+++ b/tests/Portal.test.tsx
@@ -117,32 +117,54 @@ describe('Portal', () => {
     });
   });
 
-  it('openCount', () => {
-    const Demo = ({ count, visible }: { count: number; visible: boolean }) => {
-      return (
-        <>
-          {new Array(count).fill(null).map((_, index) => (
-            <PortalWrapper key={index} visible={visible}>
-              {() => <div>2333</div>}
-            </PortalWrapper>
-          ))}
-        </>
+  describe('openCount', () => {
+    it('start as 0', () => {
+      expect(getOpenCount()).toEqual(0);
+
+      const wrapper = mount(
+        <PortalWrapper visible={false}>{() => <div>2333</div>}</PortalWrapper>,
       );
-    };
+      expect(getOpenCount()).toEqual(0);
 
-    expect(getOpenCount()).toEqual(0);
+      wrapper.setProps({ visible: true });
+      expect(getOpenCount()).toEqual(1);
 
-    const wrapper = mount(<Demo count={1} visible />);
-    expect(getOpenCount()).toEqual(1);
+      wrapper.unmount();
+    });
 
-    wrapper.setProps({ count: 2 });
-    expect(getOpenCount()).toEqual(2);
+    it('correct count', () => {
+      const Demo = ({
+        count,
+        visible,
+      }: {
+        count: number;
+        visible: boolean;
+      }) => {
+        return (
+          <>
+            {new Array(count).fill(null).map((_, index) => (
+              <PortalWrapper key={index} visible={visible}>
+                {() => <div>2333</div>}
+              </PortalWrapper>
+            ))}
+          </>
+        );
+      };
 
-    wrapper.setProps({ count: 1 });
-    expect(getOpenCount()).toEqual(1);
+      expect(getOpenCount()).toEqual(0);
 
-    wrapper.setProps({ visible: false });
-    expect(getOpenCount()).toEqual(0);
+      const wrapper = mount(<Demo count={1} visible />);
+      expect(getOpenCount()).toEqual(1);
+
+      wrapper.setProps({ count: 2 });
+      expect(getOpenCount()).toEqual(2);
+
+      wrapper.setProps({ count: 1 });
+      expect(getOpenCount()).toEqual(1);
+
+      wrapper.setProps({ visible: false });
+      expect(getOpenCount()).toEqual(0);
+    });
   });
 
   it('wrapperClassName', () => {

--- a/tests/Portal.test.tsx
+++ b/tests/Portal.test.tsx
@@ -130,6 +130,8 @@ describe('Portal', () => {
       );
     };
 
+    expect(getOpenCount()).toEqual(0);
+
     const wrapper = mount(<Demo count={1} visible />);
     expect(getOpenCount()).toEqual(1);
 


### PR DESCRIPTION
StrictMode 下 `constructor` 和 `getDerivedStateFromProps` 会多次执行，导致 `openCount` 数值错误。改造成了 `didMount` 和 `didUpdate` 不确定有没有坑。帮忙看下。

ref #https://github.com/ant-design/ant-design/issues/28228