### PR TITLE
feat: add useLayoutEffect hook

### DIFF
--- a/src/hooks/useLayoutEffect.ts
+++ b/src/hooks/useLayoutEffect.ts
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import * as React from 'react';
-import isBrowserClient from 'src/isBrowserClient';
+import isBrowserClient from '../isBrowserClient';
 
 /**
  * Wrap `React.useLayoutEffect` which will not throw warning message in test env

--- a/src/hooks/useLayoutEffect.ts
+++ b/src/hooks/useLayoutEffect.ts
@@ -1,0 +1,17 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import * as React from 'react';
+import isBrowserClient from 'src/isBrowserClient';
+
+/**
+ * Wrap `React.useLayoutEffect` which will not throw warning message in test env
+ */
+export default function useLayoutEffect(effect: React.EffectCallback, deps?: React.DependencyList) {
+  // Never happen in test env
+  if (isBrowserClient) {
+    /* istanbul ignore next */
+    React.useLayoutEffect(effect, deps);
+  } else {
+    React.useEffect(effect, deps);
+  }
+}
+/* eslint-enable */

--- a/src/isBrowserClient.ts
+++ b/src/isBrowserClient.ts
@@ -1,0 +1,4 @@
+import canUseDom from './Dom/canUseDom';
+
+/** Is client side and not jsdom */
+export default process.env.NODE_ENV !== 'test' && canUseDom();

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import useMemo from '../src/hooks/useMemo';
 import useMergedState from '../src/hooks/useMergedState';
+import useLayoutEffect from '../src/hooks/useLayoutEffect';
 
 describe('hooks', () => {
   it('useMemo', () => {
@@ -54,6 +55,35 @@ describe('hooks', () => {
       const wrapper = mount(<FC defaultValue="test" />);
 
       expect(wrapper.find('input').props().value).toEqual('test');
+    });
+  });
+
+  describe('useLayoutEffect', () => {
+    const FC = ({ defaultValue }) => {
+      const [val, setVal] = React.useState(defaultValue);
+      const [val2, setVal2] = React.useState();
+      useLayoutEffect(() => {
+        setVal2(`${val}a`);
+      }, [val]);
+      return (
+        <div>
+          <input
+            value={val}
+            onChange={e => {
+              setVal(e.target.value);
+            }}
+          />
+          <label>{val2}</label>
+        </div>
+      );
+    };
+
+    it('correct effect', () => {
+      const wrapper = mount(<FC defaultValue="test" />);
+      expect(wrapper.find('label').props().children).toEqual('testa');
+      wrapper.find('input').simulate('change', { target: { value: '1' } });
+      wrapper.update();
+      expect(wrapper.find('label').props().children).toEqual('1a');
     });
   });
 });

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -84,6 +84,9 @@ describe('hooks', () => {
       wrapper.find('input').simulate('change', { target: { value: '1' } });
       wrapper.update();
       expect(wrapper.find('label').props().children).toEqual('1a');
+      wrapper.find('input').simulate('change', { target: { value: '2' } });
+      wrapper.update();
+      expect(wrapper.find('label').props().children).toEqual('2a');
     });
   });
 });


### PR DESCRIPTION
把`rc-select`里的 `useLayoutEffect` 挪到`rc-util`。

Prepare for 
https://github.com/ant-design/ant-design/issues/30396
react-component/overflow#6
https://github.com/react-component/select/issues/614