### PR TITLE
feat: Support useId

### DIFF
--- a/src/hooks/useId.ts
+++ b/src/hooks/useId.ts
@@ -2,18 +2,22 @@ import * as React from 'react';
 
 let uuid = 0;
 
-const isTestEnv = process.env.NODE_ENV === 'test';
-const supportUseId = !!React.useId;
+/** @private Note only worked in develop env. Not work in production. */
+export function resetUuid() {
+  if (process.env.NODE_ENV !== 'production') {
+    uuid = 0;
+  }
+}
 
 export default function useId(id?: string) {
   // Inner id for accessibility usage. Only work in client side
   const [innerId, setInnerId] = React.useState<string>('ssr-id');
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  const reactNativeId = supportUseId ? React.useId() : undefined;
+  const reactNativeId = React.useId?.();
 
   React.useEffect(() => {
-    if (!supportUseId) {
+    if (!React.useId) {
       const nextId = uuid;
       uuid += 1;
 
@@ -27,7 +31,7 @@ export default function useId(id?: string) {
   }
 
   // Test env always return mock id
-  if (isTestEnv) {
+  if (process.env.NODE_ENV === 'test') {
     return 'test-id';
   }
 

--- a/src/hooks/useId.ts
+++ b/src/hooks/useId.ts
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+let uuid = 0;
+
+const isTestEnv = process.env.NODE_ENV === 'test';
+const supportUseId = !!React.useId;
+
+export default function useId(id?: string) {
+  // Inner id for accessibility usage. Only work in client side
+  const [innerId, setInnerId] = React.useState<string>('ssr-id');
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const reactNativeId = supportUseId ? React.useId() : undefined;
+
+  React.useEffect(() => {
+    if (!supportUseId) {
+      const nextId = uuid;
+      uuid += 1;
+
+      setInnerId(`rc_unique_${nextId}`);
+    }
+  }, []);
+
+  // Developer passed id is single source of truth
+  if (id) {
+    return id;
+  }
+
+  // Test env always return mock id
+  if (isTestEnv) {
+    return 'test-id';
+  }
+
+  // Return react native id or inner id
+  return reactNativeId || innerId;
+}


### PR DESCRIPTION
根据当前环境自动切换 ID：
* 在 Test 下始终产出 mock id 以确保跨 React 版本 snapshot 唯一性
* 在 SSR 下根据 React 版本选择是否使用结构化 useId 还是 ssr-id 占位符，Client 端根据对应策略注水