### PR TITLE
fix: qiankun remount app will create new container

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-util",
-  "version": "5.24.1",
+  "version": "5.24.2",
   "description": "Common Utils For React Component",
   "keywords": [
     "react",

--- a/src/Dom/dynamicCSS.ts
+++ b/src/Dom/dynamicCSS.ts
@@ -104,16 +104,26 @@ export function removeCSS(key: string, option: Options = {}) {
   existNode?.parentNode?.removeChild(existNode);
 }
 
-export function updateCSS(css: string, key: string, option: Options = {}) {
-  const container = getContainer(option);
+/**
+ * qiankun will inject `appendChild` to insert into other
+ */
+function syncRealContainer(container: Element, option: Options) {
+  const cachedRealContainer = containerCache.get(container);
 
-  // Get real parent
-  if (!containerCache.has(container)) {
+  // Find real container when not cached or cached container removed
+  if (!cachedRealContainer || !document.contains(cachedRealContainer)) {
     const placeholderStyle = injectCSS('', option);
     const { parentNode } = placeholderStyle;
     containerCache.set(container, parentNode);
     parentNode.removeChild(placeholderStyle);
   }
+}
+
+export function updateCSS(css: string, key: string, option: Options = {}) {
+  const container = getContainer(option);
+
+  // Sync real parent
+  syncRealContainer(container, option);
 
   const existNode = findExistNode(key, option);
 

--- a/tests/dynamicCSS.test.tsx
+++ b/tests/dynamicCSS.test.tsx
@@ -168,4 +168,38 @@ describe('dynamicCSS', () => {
       });
     });
   });
+
+  describe('qiankun', () => {
+    let originAppendChild: typeof document.head.appendChild;
+    let targetContainer: HTMLElement;
+
+    beforeAll(() => {
+      originAppendChild = document.head.appendChild;
+      document.head.appendChild = ele => targetContainer.appendChild(ele);
+    });
+
+    afterAll(() => {
+      document.head.appendChild = originAppendChild;
+    });
+
+    it('updateCSS', () => {
+      targetContainer = document.createElement('div');
+      document.body.appendChild(targetContainer);
+
+      // First insert
+      const firstStyle = updateCSS('body { color: red; }', 'qiankun');
+      expect(document.head.contains(firstStyle)).toBeFalsy();
+      expect(targetContainer.contains(firstStyle)).toBeTruthy();
+
+      // Mock qiankun uninstall & reinstall
+      document.body.removeChild(targetContainer);
+      targetContainer = document.createElement('div');
+      document.body.appendChild(targetContainer);
+
+      // Second insert
+      const SecondStyle = updateCSS('body { color: red; }', 'qiankun');
+      expect(document.head.contains(SecondStyle)).toBeFalsy();
+      expect(targetContainer.contains(SecondStyle)).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
qiankun 卸载 & 重新装载 时会创建新的 div，导致 cache 存在的真实 container 会过期。添加一个检测更新机制。