### PR TITLE
revert: SVGGraphicsElement is not define with older browsers

### DIFF
--- a/src/Dom/isVisible.ts
+++ b/src/Dom/isVisible.ts
@@ -3,20 +3,20 @@ export default (element: HTMLElement | SVGGraphicsElement): boolean => {
     return false;
   }
 
-  if (element instanceof HTMLElement && element.offsetParent) {
+  if ((element as HTMLElement).offsetParent) {
     return true;
   }
 
-  if (element instanceof SVGGraphicsElement && element.getBBox) {
-    const { width, height } = element.getBBox();
-    if (width || height) {
+  if ((element as SVGGraphicsElement).getBBox) {
+    const box = (element as SVGGraphicsElement).getBBox();
+    if (box.width || box.height) {
       return true;
     }
   }
 
-  if (element instanceof HTMLElement && element.getBoundingClientRect) {
-    const { width, height } = element.getBoundingClientRect();
-    if (width || height) {
+  if ((element as HTMLElement).getBoundingClientRect) {
+    const box = (element as HTMLElement).getBoundingClientRect();
+    if (box.width || box.height) {
       return true;
     }
   }


### PR DESCRIPTION
感觉这里只是为了类型而已，不应该被当作对象使用

相关问题：
https://github.com/ant-design/ant-design/issues/37814
https://github.com/ant-design/ant-design/issues/39984#issuecomment-1434820695