### PR TITLE
fix: addEventListenerWrap param target may be  nullish

### DIFF
--- a/src/Dom/addEventListener.js
+++ b/src/Dom/addEventListener.js
@@ -7,12 +7,12 @@ export default function addEventListenerWrap(target, eventType, cb, option) {
         ReactDOM.unstable_batchedUpdates(cb, e);
       }
     : cb;
-  if (target.addEventListener) {
+  if (target?.addEventListener) {
     target.addEventListener(eventType, callback, option);
   }
   return {
     remove: () => {
-      if (target.removeEventListener) {
+      if (target?.removeEventListener) {
         target.removeEventListener(eventType, callback, option);
       }
     },


### PR DESCRIPTION
When target is nullish, it will throw `TypeError: Cannot read properties of null (reading 'addEventListener')`.
So I add the optional chaining to avoid the error.

@zombieJ 