### PR TITLE
feat: [useMergedState] inject prevState to  postState(next,prev)

### DIFF
--- a/src/hooks/useMergedState.ts
+++ b/src/hooks/useMergedState.ts
@@ -22,7 +22,7 @@ export default function useMergedState<T, R = T>(
     defaultValue?: T | (() => T);
     value?: T;
     onChange?: (value: T, prevValue: T) => void;
-    postState?: (value: T) => T;
+    postState?: (value: T, prevValue?: T) => T;
   },
 ): [R, Updater<T>] {
   const { defaultValue, value, onChange, postState } = option || {};
@@ -42,13 +42,15 @@ export default function useMergedState<T, R = T>(
     }
   });
 
+  const [prevValue, setPrevValue] = useState<[T]>([mergedValue]);
+  
   const mergedValue = value !== undefined ? value : innerValue;
-  const postMergedValue = postState ? postState(mergedValue) : mergedValue;
+  const postMergedValue = postState ? postState(mergedValue,prevValue[0]) : mergedValue;
 
   // ====================== Change ======================
   const onChangeFn = useEvent(onChange);
 
-  const [prevValue, setPrevValue] = useState<[T]>([mergedValue]);
+ 
 
   useLayoutUpdateEffect(() => {
     const prev = prevValue[0];


### PR DESCRIPTION
修改前, 
可否修改的拦截器(autoClearSearchValue === true ) 需要在每一个操作前设置, 这种 case by case 的操作对人的心智负担很大, 容易出现遗漏

```jsx
 const [mergedSearchValue, setSearchValue] = useMergedState('', {
      value: searchValue !== undefined ? searchValue : inputValue,
      postState: (search) => search || '',
    });
   if (formatted) {
          const newRawValues = Array.from(new Set<RawValueType>([...rawValues, formatted]));
          triggerChange(newRawValues);
          triggerSelect(formatted, true);
          if(autoClearSearchValue) setSearchValue('');
          
        }
```

修改后, 把拦截器放到整个useMergedState 里, 这样无论在哪里调用,都可以走拦截判断, 可以大大减少bug数

```jsx
 const [mergedSearchValue, setSearchValue] = useMergedState('', {
      value: searchValue !== undefined ? searchValue : inputValue,
      postState: (search,prevSearch) => (autoClearSearchValue ? search: prevSearch) || '',
    });
   if (formatted) {
          const newRawValues = Array.from(new Set<RawValueType>([...rawValues, formatted]));
          triggerChange(newRawValues);
          triggerSelect(formatted, true);
         setSearchValue('');
        }
```

目的,减少组件bug,


