### PR TITLE
fix: incorrect insertBefore target

### DIFF
--- a/src/Dom/dynamicCSS.ts
+++ b/src/Dom/dynamicCSS.ts
@@ -75,9 +75,11 @@ export function injectCSS(css: string, option: Options = {}) {
         ['prepend', 'prependQueue'].includes(node.getAttribute(APPEND_ORDER)),
       );
       if (existStyle.length) {
-        container.insertBefore(
+        const lastStyle = existStyle[existStyle.length - 1].nextSibling;
+
+        lastStyle?.parentNode?.insertBefore(
           styleNode,
-          existStyle[existStyle.length - 1].nextSibling,
+          lastStyle,
         );
 
         return styleNode;


### PR DESCRIPTION
In some case, such as hosting as a micro app in qiankun. Style tag may not be inserted into `document.head`, so we should insert the next style into last style's `parentNode`, instead of `document.head` directly.