### PR TITLE
Fix supportRef function for preact

### DIFF
--- a/src/ref.ts
+++ b/src/ref.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import type * as React from 'react';
 import { isValidElement, ReactNode } from 'react';
-import { isFragment, isMemo } from 'react-is';
+import { ForwardRef, isFragment, isMemo } from 'react-is';
 import useMemo from './hooks/useMemo';
 
 export function fillRef<T>(ref: React.Ref<T>, node: T) {
@@ -43,14 +43,19 @@ export function supportRef(nodeOrComponent: any): boolean {
     : nodeOrComponent.type;
 
   // Function component node
-  if (typeof type === 'function' && !type.prototype?.render) {
+  if (
+    typeof type === 'function' &&
+    !type.prototype?.render &&
+    type.$$typeof !== ForwardRef
+  ) {
     return false;
   }
 
   // Class component
   if (
     typeof nodeOrComponent === 'function' &&
-    !nodeOrComponent.prototype?.render
+    !nodeOrComponent.prototype?.render &&
+    nodeOrComponent.$$typeof !== ForwardRef
   ) {
     return false;
   }


### PR DESCRIPTION
Fixes the issue described in https://github.com/ant-design/ant-design/pull/44135

Why the issue exists:
The highlighted code in `rc-dropdown` returns `true` for react and `false` for preact
https://github.com/react-component/dropdown/blob/master/src/Overlay.tsx#L25
<details>
  <summary>Screenshot</summary>

![image](https://github.com/react-component/util/assets/69504277/e353950b-c911-48b8-a6dc-2497cc60a3b0)
</details>

That's why the focus doesn't shift to the menu when using preact.

Now let's take a look at the `supportRef` code and add some console.log to it for debugging:
<details>
  <summary>Screenshot</summary>

![image](https://github.com/react-component/util/assets/69504277/bfc83dfc-3919-4fe5-810f-966c003eafb8)
</details>

And here are the results:
<details>
  <summary>react</summary>

![image](https://github.com/react-component/util/assets/69504277/f60fe8c2-e937-46de-94cd-60c598f7a73f)
</details>

<details>
  <summary>preact</summary>

![image](https://github.com/react-component/util/assets/69504277/218a2621-e37a-476e-b863-b6cdf6576a2d)
</details>

So, based on the screenshots above, we can conclude that in the case of preact, the `nodeOrComponent`  is a `function`, not an `object`, so the second condition is fulfilled and `false` is returned.

And to fix this I added an additional condition because in the screenshot above you can see that preact as well as react have a `$$typeof` property equal to `Symbol(react.forward_ref)`
![image](https://github.com/react-component/util/assets/69504277/10829e5d-520f-4288-9926-8d18c2c582a5)
