### PR TITLE
fix: raf.cancel not clean up correct map id

### DIFF
--- a/src/raf.ts
+++ b/src/raf.ts
@@ -48,4 +48,8 @@ wrapperRaf.cancel = (id: number) => {
   return caf(realId);
 };
 
+if (process.env.NODE_ENV !== 'production') {
+  wrapperRaf.ids = () => rafIds;
+}
+
 export default wrapperRaf;

--- a/src/raf.ts
+++ b/src/raf.ts
@@ -44,7 +44,7 @@ const wrapperRaf = (callback: () => void, times = 1): number => {
 
 wrapperRaf.cancel = (id: number) => {
   const realId = rafIds.get(id);
-  cleanup(realId);
+  cleanup(id);
   return caf(realId);
 };
 

--- a/tests/raf.test.js
+++ b/tests/raf.test.js
@@ -20,11 +20,19 @@ describe('raf', () => {
   it('cancel', done => {
     let bamboo = false;
 
+    // Call some native raf
+    for (let i = 0; i < 10; i += 1) {
+      const nativeId = requestAnimationFrame(() => {});
+      cancelAnimationFrame(nativeId);
+    }
+
     const id = raf(() => {
       bamboo = true;
     }, 2);
+    expect(raf.ids().has(id)).toBeTruthy();
 
     raf.cancel(id);
+    expect(raf.ids().has(id)).toBeFalsy();
 
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {


### PR DESCRIPTION
这个错误会导致删除错误 id 导致 `cancel` 无法正确清理 raf。但是因为应用中有非常多的 raf，导致原生 id 会被迅速提升而不会遇到被误删的问题。