### PR TITLE
fix: modify compare logic of useComposeRef memo

### DIFF
--- a/src/ref.ts
+++ b/src/ref.ts
@@ -33,7 +33,7 @@ export function useComposeRef<T>(...refs: React.Ref<T>[]): React.Ref<T> {
     () => composeRef(...refs),
     refs,
     (prev, next) =>
-      prev.length !== next.length || prev.every((ref, i) => ref !== next[i]),
+      prev.length !== next.length || prev.some((ref, i) => ref !== next[i]),
   );
 }
 


### PR DESCRIPTION
Old logic of comparation is wrong in this case: `prev: [1, 2] / next: [1, 3]`.
This commit resolves this error case.