### PR TITLE
fix: not force fill auto

### DIFF
--- a/docs/examples/getScrollBarSize.tsx
+++ b/docs/examples/getScrollBarSize.tsx
@@ -22,20 +22,23 @@ const cssText = `
 `;
 
 export default () => {
+  const defaultRef = React.useRef<HTMLDivElement>();
   const webkitRef = React.useRef<HTMLDivElement>();
   const scrollRef = React.useRef<HTMLDivElement>();
   const [sizeData, setSizeData] = React.useState('');
 
   React.useEffect(() => {
     const originSize = getScrollBarSize();
+    const defaultSize = getTargetScrollBarSize(defaultRef.current);
     const webkitSize = getTargetScrollBarSize(webkitRef.current);
     const scrollSize = getTargetScrollBarSize(scrollRef.current);
 
     setSizeData(
       [
         `Origin: ${originSize}`,
+        `Default: ${defaultSize.width}/${defaultSize.height}`,
         `Webkit: ${webkitSize.width}/${webkitSize.height}`,
-        `Webkit: ${scrollSize.width}/${scrollSize.height}`,
+        `Scroll: ${scrollSize.width}/${scrollSize.height}`,
       ].join(', '),
     );
   }, []);
@@ -55,6 +58,7 @@ export default () => {
           overflow: 'scroll',
           background: 'yellow',
         }}
+        ref={defaultRef}
       >
         Origin
       </div>

--- a/src/getScrollBarSize.tsx
+++ b/src/getScrollBarSize.tsx
@@ -36,16 +36,22 @@ function measureScrollbarSize(ele?: HTMLElement): ScrollBarSize {
 
     // Set Webkit style
     const webkitScrollbarStyle = getComputedStyle(ele, '::-webkit-scrollbar');
+    const width = parseInt(webkitScrollbarStyle.width, 10);
+    const height = parseInt(webkitScrollbarStyle.height, 10);
 
     // Try wrap to handle CSP case
     try {
+      const widthStyle = width ? `width: ${webkitScrollbarStyle.width};` : '';
+      const heightStyle = height
+        ? `height: ${webkitScrollbarStyle.height};`
+        : '';
+
       updateCSS(
         `
-     #${randomId}::-webkit-scrollbar {
-        width: ${webkitScrollbarStyle.width};
-        height: ${webkitScrollbarStyle.height};
-     }
-    `,
+#${randomId}::-webkit-scrollbar {
+${widthStyle}
+${heightStyle}
+}`,
         randomId,
       );
     } catch (e) {
@@ -53,8 +59,8 @@ function measureScrollbarSize(ele?: HTMLElement): ScrollBarSize {
       console.error(e);
 
       // Get from style directly
-      fallbackWidth = parseInt(webkitScrollbarStyle.width, 10);
-      fallbackHeight = parseInt(webkitScrollbarStyle.height, 10);
+      fallbackWidth = width;
+      fallbackHeight = height;
     }
   }
 


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/47754

Chrome 下，`::-webkit-scrollbar` 设置 `width/height: atuo` 与 `style` 默认的 `width/height: atuo` 行为不一致。显式设置会变成固定占位，而默认 `auto` 则不会。

PS: JSDOM 不能模拟这种情况