### PR TITLE
feat: getNodeRef

### DIFF
--- a/tests/ref.test.tsx
+++ b/tests/ref.test.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable no-eval */
 import { fireEvent, render } from '@testing-library/react';
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React from 'react';
 import useEvent from '../src/hooks/useEvent';
 import {
   composeRef,
+  getNodeRef,
   supportNodeRef,
   supportRef,
   useComposeRef,
@@ -198,5 +200,12 @@ describe('ref', () => {
       expect(supportNodeRef(com) && com.ref).toBeFalsy();
       expect(supportNodeRef(refCom) && refCom.ref).toBeTruthy();
     });
+  });
+
+  it('getNodeRef', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const node = <div ref={ref} />;
+
+    expect(getNodeRef(node)).toBe(ref);
   });
 });


### PR DESCRIPTION
和 React 版本强绑定的，无论哪个优先在另一个版本里都会报 warning。根据版本做一下判断再使用。