### PR TITLE
Corrects console log type for warning

### DIFF
--- a/src/test/isEqual.test.ts
+++ b/src/test/isEqual.test.ts
@@ -2,18 +2,18 @@ import isEqual from '../isEqual';
 import warning from '../warning';
 
 describe('isEqual', () => {
-  let errorSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
 
   beforeAll(() => {
-    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    errorSpy.mockReset();
+    warnSpy.mockReset();
   });
 
   afterAll(() => {
-    errorSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
   it('should equal', () => {
@@ -98,7 +98,7 @@ describe('isEqual', () => {
     obj.obj = obj;
     const obj2 = { a: 1, b: 2, c: [1, 2], obj: null };
     warning(false, 'error');
-    expect(errorSpy).toHaveBeenCalledWith('Warning: error');
+    expect(warnSpy).toHaveBeenCalledWith('Warning: error');
 
     const valueIsEqual = isEqual(obj, obj2);
     expect(valueIsEqual).toBe(false);

--- a/src/warning.ts
+++ b/src/warning.ts
@@ -39,7 +39,7 @@ export function warning(valid: boolean, message: string) {
     );
 
     if (finalMessage) {
-      console.error(`Warning: ${finalMessage}`);
+      console.warn(`Warning: ${finalMessage}`);
     }
   }
 }

--- a/tests/warning.test.js
+++ b/tests/warning.test.js
@@ -11,7 +11,7 @@ describe('warning', () => {
   });
 
   it('warning', () => {
-    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     warning(false, '[antd Component] test hello world');
     expect(warnSpy).toHaveBeenCalledWith(
       'Warning: [antd Component] test hello world',
@@ -72,7 +72,6 @@ describe('warning', () => {
 
   describe('preMessage', () => {
     it('modify message', () => {
-      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
       warning.preMessage((msg, type) => {
@@ -87,12 +86,11 @@ describe('warning', () => {
       });
 
       warning(false, 'warn');
-      warning.noteOnce(false, 'note');
+      expect(warnSpy).toHaveBeenCalledWith('Warning: WW-warn');
 
-      expect(errSpy).toHaveBeenCalledWith('Warning: WW-warn');
+      warning.noteOnce(false, 'note');
       expect(warnSpy).toHaveBeenCalledWith('Note: NN-note');
 
-      errSpy.mockRestore();
       warnSpy.mockRestore();
     });
   });


### PR DESCRIPTION
Corrects the type of console message for warnings.

https://github.com/react-component/util/issues/347