### PR TITLE
fix: hasValue should resolve null type

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.3",
+    "lodash.isnil": "^4.0.0",
     "react-is": "^18.2.0"
   },
   "devDependencies": {

--- a/src/hooks/useMergedState.ts
+++ b/src/hooks/useMergedState.ts
@@ -1,15 +1,15 @@
 import useEvent from './useEvent';
 import { useLayoutUpdateEffect } from './useLayoutEffect';
 import useState from './useState';
-
+import isNil from 'lodash.isnil';
 type Updater<T> = (
   updater: T | ((origin: T) => T),
   ignoreDestroy?: boolean,
 ) => void;
 
-/** We only think `undefined` is empty */
+/** We think `undefined` and `null` is empty */
 function hasValue(value: any) {
-  return value !== undefined;
+  return !isNil(value);
 }
 
 /**

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -74,6 +74,17 @@ describe('hooks', () => {
       expect(container.querySelector('.txt').textContent).toEqual('');
     });
 
+    it('control of to null', () => {
+      const { container, rerender } = render(<FC value="test" />);
+
+      expect(container.querySelector('input').value).toEqual('test');
+      expect(container.querySelector('.txt').textContent).toEqual('test');
+
+      rerender(<FC value={null} />);
+      expect(container.querySelector('input').value).toEqual('test');
+      expect(container.querySelector('.txt').textContent).toEqual('');
+    });
+
     describe('correct defaultValue', () => {
       it('raw', () => {
         const { container } = render(<FC defaultValue="test" />);


### PR DESCRIPTION
When I am using the rc picker component,

I found that when value is null and defaultvalue is another value, the value of value will be used at this time

But when value is undefined and defaultvalue is another value, the value of defaultvalue will be used at this time

Finally, it was discovered that the useMergedState hook was called inside the rc picker, and there was a function called 'hasValue' inside that only judges undefined.

I think this is not as expected. The 'hasValue' method should be implemented with reference to 'isNil'