### PR TITLE
fix: isFragment not support React 19

### DIFF
--- a/src/Children/toArray.ts
+++ b/src/Children/toArray.ts
@@ -1,5 +1,5 @@
+import isFragment from '../React/isFragment';
 import React from 'react';
-import { isFragment } from 'react-is';
 
 export interface Option {
   keepEmpty?: boolean;

--- a/src/React/isFragment.ts
+++ b/src/React/isFragment.ts
@@ -1,0 +1,19 @@
+const REACT_ELEMENT_TYPE_18 = Symbol.for('react.element');
+const REACT_ELEMENT_TYPE_19 = Symbol.for('react.transitional.element');
+const REACT_FRAGMENT_TYPE = Symbol.for('react.fragment');
+
+/**
+ * Compatible with React 18 or 19 to check if node is a Fragment.
+ */
+export default function isFragment(object: any) {
+  return (
+    // Base object type
+    object &&
+    typeof object === 'object' &&
+    // React Element type
+    (object.$$typeof === REACT_ELEMENT_TYPE_18 ||
+      object.$$typeof === REACT_ELEMENT_TYPE_19) &&
+    // React Fragment type
+    object.type === REACT_FRAGMENT_TYPE
+  );
+}

--- a/src/ref.ts
+++ b/src/ref.ts
@@ -1,7 +1,8 @@
 import type * as React from 'react';
 import { isValidElement } from 'react';
-import { ForwardRef, isFragment, isMemo } from 'react-is';
+import { ForwardRef, isMemo } from 'react-is';
 import useMemo from './hooks/useMemo';
+import isFragment from './React/isFragment';
 
 export const fillRef = <T>(ref: React.Ref<T>, node: T) => {
   if (typeof ref === 'function') {

--- a/tests/toArray-19.test.tsx
+++ b/tests/toArray-19.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import toArray from '../src/Children/toArray';
+
+jest.mock('react', () => {
+  const react19 = jest.requireActual('react-19');
+  return react19;
+});
+
+jest.mock('react-dom', () => {
+  const reactDom19 = jest.requireActual('react-dom-19');
+  return reactDom19;
+});
+
+jest.mock('react-dom/client', () => {
+  const reactDom19Client = jest.requireActual('react-dom-19/client');
+  return reactDom19Client;
+});
+
+jest.mock('react-dom/test-utils', () => {
+  const reactDom19Test = jest.requireActual('react-dom-19/test-utils');
+  return reactDom19Test;
+});
+
+class UL extends React.Component<{
+  children?: React.ReactNode;
+}> {
+  render() {
+    return <ul>{this.props.children}</ul>;
+  }
+}
+
+describe('toArray', () => {
+  it('Fragment', () => {
+    const ulRef = React.createRef<UL>();
+
+    render(
+      <UL ref={ulRef}>
+        <li key="1">1</li>
+        <>
+          <li key="2">2</li>
+          <li key="3">3</li>
+        </>
+        <React.Fragment>
+          <>
+            <li key="4">4</li>
+            <li key="5">5</li>
+          </>
+        </React.Fragment>
+      </UL>,
+    );
+
+    const children = toArray(ulRef.current.props.children);
+    expect(children).toHaveLength(5);
+    expect(children.map(c => c.key)).toEqual(['1', '2', '3', '4', '5']);
+  });
+});


### PR DESCRIPTION
React 19 对 Fragment 的定义变了，导致 `react-is` 不能同时支持两个版本， `rc-util` 里自行吃掉这个。

fix https://github.com/ant-design/ant-design/issues/51918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 新增 `isFragment` 函数，用于判断对象是否为 React Fragment。
	- 新增测试文件 `toArray-19.test.tsx`，验证 `toArray` 函数对 React Fragment 的处理。

- **Bug 修复**
	- 简化了 React 元素和 refs 的处理逻辑，特别是在处理 Fragment 时。

- **文档**
	- 更新了导入语句以反映新的模块结构。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->