### PR TITLE
fix: reactRender is not a function in React 19

### DIFF
--- a/src/React/render.ts
+++ b/src/React/render.ts
@@ -56,7 +56,7 @@ function modernRender(node: React.ReactElement, container: ContainerType) {
 }
 
 function legacyRender(node: React.ReactElement, container: ContainerType) {
-  reactRender(node, container);
+  reactRender?.(node, container);
 }
 
 /** @private Test usage. Not work in prod */


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/52080

`reactRender` is undefined in react-dom@19.