### PR TITLE
remove React.findDOMNode

### DIFF
--- a/src/Dom/findDOMNode.ts
+++ b/src/Dom/findDOMNode.ts
@@ -37,7 +37,7 @@ export default function findDOMNode<T = Element | Text>(
     return domNode as T;
   }
 
-  if (node && typeof node === 'object' && 'current' in node) {
+  if (node && typeof node === 'object' && 'current' in node && isDOM(node.current)) {
     return node.current as T;
   }
 

--- a/src/Dom/findDOMNode.ts
+++ b/src/Dom/findDOMNode.ts
@@ -37,8 +37,11 @@ export default function findDOMNode<T = Element | Text>(
     return domNode as T;
   }
 
-  if (node && typeof node === 'object' && 'current' in node && isDOM(node.current)) {
-    return node.current as T;
+  if (node && typeof node === 'object' && 'current' in node) {
+    const refDomNode = getDOM(node.current);
+    if (refDomNode) {
+      return refDomNode as T;
+    }
   }
 
   return null;

--- a/src/Dom/findDOMNode.ts
+++ b/src/Dom/findDOMNode.ts
@@ -41,13 +41,5 @@ export default function findDOMNode<T = Element | Text>(
     return node.current as T;
   }
 
-  if (node instanceof React.Component) {
-    console.warn(
-      'findDOMNode is deprecated in StrictMode. ' +
-        'Please use ref instead to access the DOM node.',
-    );
-    return null;
-  }
-
   return null;
 }

--- a/src/Dom/findDOMNode.ts
+++ b/src/Dom/findDOMNode.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 export function isDOM(node: any): node is HTMLElement | SVGElement {
   // https://developer.mozilla.org/en-US/docs/Web/API/Element
@@ -26,15 +25,28 @@ export function getDOM(node: any): HTMLElement | SVGElement | null {
  * Return if a node is a DOM node. Else will return by `findDOMNode`
  */
 export default function findDOMNode<T = Element | Text>(
-  node: React.ReactInstance | HTMLElement | SVGElement | { nativeElement: T },
-): T {
+  node:
+    | React.ReactInstance
+    | HTMLElement
+    | SVGElement
+    | { nativeElement: T }
+    | { current: T },
+): T | null {
   const domNode = getDOM(node);
   if (domNode) {
     return domNode as T;
   }
 
+  if (node && typeof node === 'object' && 'current' in node) {
+    return node.current as T;
+  }
+
   if (node instanceof React.Component) {
-    return ReactDOM.findDOMNode?.(node) as unknown as T;
+    console.warn(
+      'findDOMNode is deprecated in StrictMode. ' +
+        'Please use ref instead to access the DOM node.',
+    );
+    return null;
   }
 
   return null;

--- a/tests/findDOMNode.test.tsx
+++ b/tests/findDOMNode.test.tsx
@@ -76,7 +76,26 @@ describe('findDOMNode', () => {
       expect(true).toBeFalsy();
     }
   });
+  it('should return DOM node from ref.current', () => {
+    const TestComponent = React.forwardRef<HTMLDivElement>((_, ref) => {
+      return <div ref={ref}>test</div>;
+    });
 
+    const elementRef = React.createRef<HTMLDivElement>();
+    const { container } = render(
+      <React.StrictMode>
+        <TestComponent ref={elementRef} />
+      </React.StrictMode>,
+    );
+
+    expect(findDOMNode(elementRef)).toBe(container.firstChild);
+  });
+
+  it('should return null if ref is not mounted', () => {
+    const elementRef = React.createRef<HTMLDivElement>();
+
+    expect(findDOMNode(elementRef)).toBeNull();
+  });
   it('nativeElement', () => {
     const Element = React.forwardRef<{ nativeElement: HTMLDivElement }>(
       (_, ref) => {

--- a/tests/findDOMNode.test.tsx
+++ b/tests/findDOMNode.test.tsx
@@ -35,12 +35,13 @@ describe('findDOMNode', () => {
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     class DOMWrapper extends React.Component {
+      private elementRef = React.createRef<HTMLDivElement>();
       getDOM = () => {
-        return findDOMNode(this);
+        return findDOMNode(this.elementRef);
       };
 
       render() {
-        return <div />;
+        return <div ref={this.elementRef} />;
       }
     }
 
@@ -53,7 +54,7 @@ describe('findDOMNode', () => {
 
     expect(wrapperRef.current!.getDOM()).toBe(container.firstChild);
 
-    expect(errSpy).toHaveBeenCalled();
+    expect(errSpy).not.toHaveBeenCalled();
     errSpy.mockRestore();
   });
 


### PR DESCRIPTION
remove React.findDOMNode   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新特性**
  - 更新了 `findDOMNode` 函数，支持新的类型 `{ current: T }`，并可能返回 `null`。
  - 测试用例中添加了新的私有属性 `elementRef`，以增强组件对其 DOM 节点的识别能力。
  - 新增测试用例，验证从 `ref.current` 返回 DOM 节点的正确性。
  - 新增测试用例，检查未挂载的 `ref` 返回 `null` 的情况。

- **错误修复**
  - 修改了 `DOMWrapper` 类的测试期望，从期望错误更改为不期望错误。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->