### PR TITLE
fix: ref could be passed as a prop in 19.x

### DIFF
--- a/src/ref.ts
+++ b/src/ref.ts
@@ -4,6 +4,8 @@ import { ForwardRef, isMemo } from 'react-is';
 import useMemo from './hooks/useMemo';
 import isFragment from './React/isFragment';
 
+const ReactMajorVersion = Number(version.split('.')[0]);
+
 export const fillRef = <T>(ref: React.Ref<T>, node: T) => {
   if (typeof ref === 'function') {
     ref(node);
@@ -43,10 +45,7 @@ export const supportRef = (nodeOrComponent: any): boolean => {
   }
 
   // React 19 no need `forwardRef` anymore. So just pass if is a React element.
-  if (
-    isReactElement(nodeOrComponent) &&
-    version.startsWith('19.')
-  ) {
+  if (isReactElement(nodeOrComponent) && ReactMajorVersion >= 19) {
     return true;
   }
 

--- a/src/ref.ts
+++ b/src/ref.ts
@@ -45,7 +45,7 @@ export const supportRef = (nodeOrComponent: any): boolean => {
   // React 19 no need `forwardRef` anymore. So just pass if is a React element.
   if (
     isReactElement(nodeOrComponent) &&
-    (nodeOrComponent as any).props.propertyIsEnumerable('ref')
+    React.version.startsWith('19.')
   ) {
     return true;
   }

--- a/src/ref.ts
+++ b/src/ref.ts
@@ -1,5 +1,5 @@
 import type * as React from 'react';
-import { isValidElement } from 'react';
+import { isValidElement, version } from 'react';
 import { ForwardRef, isMemo } from 'react-is';
 import useMemo from './hooks/useMemo';
 import isFragment from './React/isFragment';
@@ -45,7 +45,7 @@ export const supportRef = (nodeOrComponent: any): boolean => {
   // React 19 no need `forwardRef` anymore. So just pass if is a React element.
   if (
     isReactElement(nodeOrComponent) &&
-    React.version.startsWith('19.')
+    version.startsWith('19.')
   ) {
     return true;
   }

--- a/tests/ref-19.test.tsx
+++ b/tests/ref-19.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-eval */
 import React from 'react';
-import { getNodeRef, useComposeRef } from '../src/ref';
+import { getNodeRef, useComposeRef, supportRef } from '../src/ref';
 import { render } from '@testing-library/react';
 
 jest.mock('react', () => {
@@ -75,5 +75,21 @@ describe('ref: React 19', () => {
 
     expect(outerRef.current?.className).toBe('bamboo');
     expect(container.querySelector('.test-output')?.textContent).toBe('bamboo');
+  });
+
+  it('supportRef with not provide ref', () => {
+    const Empty = () => <div />;
+
+    const Checker = ({ children }: { children: React.ReactElement }) => {
+      return <p>{String(supportRef(children))}</p>;
+    };
+
+    const { container } = render(
+      <Checker>
+        <Empty />
+      </Checker>,
+    );
+
+    expect(container.querySelector('p')?.textContent).toBe('true');
   });
 });


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/52282#issuecomment-2642517899

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **重构**
	- 调整了内部引用处理逻辑，以支持 React 19，采用版本判断方式替代之前的属性检测方法，确保在新版 React 环境下正常工作。
- **测试**
	- 为 `supportRef` 函数添加了新测试用例，以验证在未提供 ref 的情况下的行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->