### PR TITLE
feat(mergeProps): utility to merge component props and global config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { default as useEvent } from './hooks/useEvent';
 export { default as useMergedState } from './hooks/useMergedState';
+export { default as mergeProps } from './mergeProps';
 export { supportNodeRef, supportRef, useComposeRef } from './ref';
 export { default as get } from './utils/get';
 export { default as set } from './utils/set';

--- a/src/mergeProps.ts
+++ b/src/mergeProps.ts
@@ -1,0 +1,7 @@
+export default function mergeProps<A, B, C>(
+  defaultProps: A,
+  config: B,
+  props: C,
+): A & B & C {
+  return { ...defaultProps, ...config, ...props };
+}

--- a/tests/mergeProps.test.ts
+++ b/tests/mergeProps.test.ts
@@ -1,0 +1,15 @@
+import mergeProps from '../src/mergeProps';
+
+test('merge className', () => {
+  expect(
+    mergeProps(
+      { type: 'default', shape: 'round' },
+      { className: 'foo', type: 'secondary' },
+      { className: 'bar' },
+    ),
+  ).toEqual({
+    className: 'bar',
+    type: 'secondary',
+    shape: 'round',
+  });
+});


### PR DESCRIPTION
用通用的语法来取代目前组件中各种手动合并 props 的代码，减少代码量，更易读。

```js
const { className, classNames, style, styles } = mergeProps(context, props);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增了 `mergeProps` 工具函数，用于合并多个对象属性，后传入的对象属性会覆盖前面的属性。
* **测试**
  * 添加了针对 `mergeProps` 函数的单元测试，验证对象属性合并的正确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->