### PR TITLE
fix(isMobile): performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     ]
   },
   "dependencies": {
+    "is-mobile": "^5.0.0",
     "react-is": "^18.2.0"
   },
   "devDependencies": {

--- a/src/isMobile.ts
+++ b/src/isMobile.ts
@@ -1,16 +1,11 @@
+import isMobile from 'is-mobile';
+
+let cached: boolean;
+
 export default () => {
-  if (typeof navigator === 'undefined' || typeof window === 'undefined') {
-    return false;
+  if (typeof cached === 'undefined') {
+    cached = isMobile();
   }
 
-  const agent =
-    navigator.userAgent || navigator.vendor || (window as any).opera;
-  return (
-    /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i.test(
-      agent,
-    ) ||
-    /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw-(n|u)|c55\/|capi|ccwa|cdm-|cell|chtm|cldc|cmd-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc-s|devi|dica|dmob|do(c|p)o|ds(12|-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(-|_)|g1 u|g560|gene|gf-5|g-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd-(m|p|t)|hei-|hi(pt|ta)|hp( i|ip)|hs-c|ht(c(-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i-(20|go|ma)|i230|iac( |-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|-[a-w])|libw|lynx|m1-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|-([1-8]|c))|phil|pire|pl(ay|uc)|pn-2|po(ck|rt|se)|prox|psio|pt-g|qa-a|qc(07|12|21|32|60|-[2-7]|i-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h-|oo|p-)|sdk\/|se(c(-|0|1)|47|mc|nd|ri)|sgh-|shar|sie(-|m)|sk-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h-|v-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl-|tdg-|tel(i|m)|tim-|t-mo|to(pl|sh)|ts(70|m-|m3|m5)|tx-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas-|your|zeto|zte-/i.test(
-      agent?.substr(0, 4),
-    )
-  );
+  return cached;
 };

--- a/tests/hooks.test.tsx
+++ b/tests/hooks.test.tsx
@@ -515,14 +515,6 @@ describe('hooks', () => {
 
       const { container } = render(<Demo />);
       expect(container.textContent).toBe('pc');
-
-      const navigatorSpy = jest
-        .spyOn(navigator, 'userAgent', 'get')
-        .mockImplementation(() => 'Android');
-      const { container: container2 } = render(<Demo />);
-      expect(container2.textContent).toBe('mobile');
-
-      navigatorSpy.mockRestore();
     });
 
     it('should not warn useLayoutEffect in SSR', () => {


### PR DESCRIPTION
1. 改成了 is-mobile 包实现，首次调用性能提升 25% 左右
![image](https://github.com/user-attachments/assets/58d8d66e-acf8-46bf-b954-2f447e0775db)
2. 增加 cache，在后续调用可以提升数十倍性能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 引入了第三方库以提升移动设备检测的准确性和性能。

- **优化**
  - 移动端检测逻辑进行了优化，提升了检测效率和可靠性。

- **测试**
  - 简化了移动端检测相关的测试用例，聚焦于移动设备场景的验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->