### PR TITLE
feat(export)!: restrict to only root path import

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,13 @@
     "lib",
     "es"
   ],
+  "exports": {
+    ".": {
+      "types": "./es/index.d.ts",
+      "require": "./lib/index.js",
+      "import": "./es/index.js"
+    }
+  },
   "scripts": {
     "build": "dumi build",
     "compile": "father build",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,64 @@
-export { default as useEvent } from './hooks/useEvent';
-export { default as useMergedState } from './hooks/useMergedState';
-export { supportNodeRef, supportRef, useComposeRef } from './ref';
 export { default as get } from './utils/get';
 export { default as set, merge } from './utils/set';
-export { default as warning, noteOnce } from './warning';
-export { default as omit } from './omit';
 export { default as toArray } from './Children/toArray';
+export { default as isFragment } from './React/isFragment';
+export { render, unmount } from './React/render';
+export { spyElementPrototype, spyElementPrototypes } from './test/domHook';
+export { default as composeProps } from './composeProps';
+export {
+  default as getScrollBarSize,
+  getTargetScrollBarSize,
+} from './getScrollBarSize';
+export { default as isEqual } from './isEqual';
+export { default as isMobile } from './isMobile';
+export { default as KeyCode } from './KeyCode';
+export { default as omit } from './omit';
+export { default as pickAttrs } from './pickAttrs';
+export type { PickConfig } from './pickAttrs';
+export { default as Portal } from './Portal';
+export type { PortalRef, PortalProps } from './Portal';
+export { default as PortalWrapper } from './PortalWrapper';
+export type { GetContainer, PortalWrapperProps } from './PortalWrapper';
+export { default as proxyObject } from './proxyObject';
+export { default as wrapperRaf } from './raf';
+export {
+  fillRef,
+  composeRef,
+  useComposeRef,
+  supportRef,
+  supportNodeRef,
+  getNodeRef,
+} from './ref';
+export { default as setStyle } from './setStyle';
+export { SetStyleOptions } from './setStyle';
+export { default as warning, noteOnce } from './warning';
+
+// DOM
+export { default as canUseDom } from './Dom/canUseDom';
+export { default as contains } from './Dom/contains';
+export type { ContainerType, Prepend, AppendType } from './Dom/dynamicCSS';
+export { injectCSS, removeCSS, updateCSS } from './Dom/dynamicCSS';
+export { default as findDOMNode, isDOM, getDOM } from './Dom/findDOMNode';
+export {
+  getFocusNodeList,
+  saveLastFocusNode,
+  clearLastFocusNode,
+  backLastFocusNode,
+  limitTabRange,
+} from './Dom/focus';
+export { default as isVisible } from './Dom/isVisible';
+export { default as ScrollLocker } from './Dom/scrollLocker';
+export type { scrollLockOptions } from './Dom/scrollLocker';
+export { inShadow, getShadowRoot } from './Dom/shadow';
+export { isStyleSupport } from './Dom/styleChecker';
+
+// Hooks
+export { default as useEffect } from './hooks/useEffect';
+export { default as useEvent } from './hooks/useEvent';
+export { default as useId } from './hooks/useId';
+export { default as useLayoutEffect } from './hooks/useLayoutEffect';
+export { default as useMemo } from './hooks/useMemo';
+export { default as useMergedState } from './hooks/useMergedState';
+export { default as useMobile } from './hooks/useMobile';
+export { default as useState } from './hooks/useState';
+export { default as useSyncState } from './hooks/useSyncState';

--- a/tests/isEqual.test.ts
+++ b/tests/isEqual.test.ts
@@ -1,5 +1,5 @@
-import isEqual from '../isEqual';
-import warning from '../warning';
+import isEqual from '../src/isEqual';
+import warning from '../src/warning';
 
 describe('isEqual', () => {
   let errorSpy: jest.SpyInstance;


### PR DESCRIPTION
禁止使用 `import xxx from '@rc-component/util/lib/xxx'`，这样有几个好处：

1. 避免造成 cjs/esm 混用等问题，影响性能和打包体积
2. 避免因包内文件名路径变化导致依赖项目构建失败
3. 避免一些内部方法被暴露出来