### PR TITLE
feat: Support usePropState

### DIFF
--- a/src/hooks/useControlledState.ts
+++ b/src/hooks/useControlledState.ts
@@ -8,7 +8,7 @@ type Updater<T> = (updater: T | ((origin: T) => T)) => void;
  * From React 18, we do not need safe `useState` since it will not throw for unmounted update.
  * This hooks remove the `onChange` & `postState` logic since we only need basic merged state logic.
  */
-export default function usePropState<T>(
+export default function useControlledState<T>(
   defaultStateValue: T | (() => T),
   value?: T,
 ): [T, Updater<T>] {

--- a/src/hooks/useMergedState.ts
+++ b/src/hooks/useMergedState.ts
@@ -13,7 +13,7 @@ function hasValue(value: any) {
 }
 
 /**
- * @deprecated Please use `usePropState` instead if not need support < React 18.
+ * @deprecated Please use `useControlledState` instead if not need support < React 18.
  * Similar to `useState` but will use props value if provided.
  * Note that internal use rc-util `useState` hook.
  */

--- a/src/hooks/useMergedState.ts
+++ b/src/hooks/useMergedState.ts
@@ -13,6 +13,7 @@ function hasValue(value: any) {
 }
 
 /**
+ * @deprecated Please use `usePropState` instead if not need support < React 18.
  * Similar to `useState` but will use props value if provided.
  * Note that internal use rc-util `useState` hook.
  */

--- a/src/hooks/usePropState.ts
+++ b/src/hooks/usePropState.ts
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import useLayoutEffect from './useLayoutEffect';
+
+type Updater<T> = (updater: T | ((origin: T) => T)) => void;
+
+/**
+ * Similar to `useState` but will use props value if provided.
+ * From React 18, we do not need safe `useState` since it will not throw for unmounted update.
+ * This hooks remove the `onChange` & `postState` logic since we only need basic merged state logic.
+ */
+export default function usePropState<T>(
+  defaultStateValue: T | (() => T),
+  value?: T,
+): [T, Updater<T>] {
+  const [innerValue, setInnerValue] = useState<T>(defaultStateValue);
+
+  const mergedValue = value !== undefined ? value : innerValue;
+
+  useLayoutEffect(
+    mount => {
+      if (!mount) {
+        setInnerValue(value);
+      }
+    },
+    [value],
+  );
+
+  return [
+    // Value
+    mergedValue,
+    // Update function
+    setInnerValue,
+  ];
+}

--- a/tests/hooks.test.tsx
+++ b/tests/hooks.test.tsx
@@ -8,6 +8,7 @@ import useMergedState from '../src/hooks/useMergedState';
 import useMobile from '../src/hooks/useMobile';
 import useState from '../src/hooks/useState';
 import useSyncState from '../src/hooks/useSyncState';
+import usePropState from '../src/hooks/usePropState';
 
 global.disableUseId = false;
 
@@ -308,6 +309,160 @@ describe('hooks', () => {
 
       const Demo: React.FC = () => {
         const [] = useMergedState(undefined);
+        count += 1;
+        return null;
+      };
+
+      render(<Demo />);
+      expect(count).toBe(1);
+    });
+  });
+
+  describe('usePropState', () => {
+    const FC: React.FC<{
+      value?: string;
+      defaultValue?: string | (() => string);
+    }> = props => {
+      const { value, defaultValue } = props;
+      const [val, setVal] = usePropState<string>(defaultValue ?? null, value);
+      return (
+        <>
+          <input
+            value={val}
+            onChange={e => {
+              setVal(e.target.value);
+            }}
+          />
+          <span className="txt">{val}</span>
+        </>
+      );
+    };
+
+    it('still control of to undefined', () => {
+      const { container, rerender } = render(<FC value="test" />);
+
+      expect(container.querySelector('input').value).toEqual('test');
+      expect(container.querySelector('.txt').textContent).toEqual('test');
+
+      rerender(<FC value={undefined} />);
+      expect(container.querySelector('input').value).toEqual('test');
+      expect(container.querySelector('.txt').textContent).toEqual('');
+    });
+
+    describe('correct defaultValue', () => {
+      it('raw', () => {
+        const { container } = render(<FC defaultValue="test" />);
+
+        expect(container.querySelector('input').value).toEqual('test');
+      });
+
+      it('func', () => {
+        const { container } = render(<FC defaultValue={() => 'bamboo'} />);
+
+        expect(container.querySelector('input').value).toEqual('bamboo');
+      });
+    });
+
+    it('not rerender when setState as deps', () => {
+      let renderTimes = 0;
+
+      const Test = () => {
+        const [val, setVal] = usePropState(0);
+
+        React.useEffect(() => {
+          renderTimes += 1;
+          expect(renderTimes < 10).toBeTruthy();
+
+          setVal(1);
+        }, [setVal]);
+
+        return <div>{val}</div>;
+      };
+
+      const { container } = render(<Test />);
+      expect(container.firstChild.textContent).toEqual('1');
+    });
+
+    it('React 18 should not reset to undefined', () => {
+      const Demo = () => {
+        const [val] = usePropState(33, undefined);
+
+        return <div>{val}</div>;
+      };
+
+      const { container } = render(
+        <React.StrictMode>
+          <Demo />
+        </React.StrictMode>,
+      );
+
+      expect(container.querySelector('div').textContent).toEqual('33');
+    });
+
+    it('uncontrolled to controlled', () => {
+      const Demo: React.FC<Readonly<{ value?: number }>> = ({ value }) => {
+        const [mergedValue, setMergedValue] = usePropState<number>(
+          () => 233,
+          value,
+        );
+
+        return (
+          <span
+            onClick={() => {
+              setMergedValue(v => v + 1);
+              setMergedValue(v => v + 1);
+            }}
+            onMouseEnter={() => {
+              setMergedValue(1);
+            }}
+          >
+            {mergedValue}
+          </span>
+        );
+      };
+
+      const { container, rerender } = render(<Demo />);
+      expect(container.textContent).toEqual('233');
+
+      // Update value
+      rerender(<Demo value={1} />);
+      expect(container.textContent).toEqual('1');
+
+      // Click update
+      rerender(<Demo value={undefined} />);
+      fireEvent.mouseEnter(container.querySelector('span'));
+      fireEvent.click(container.querySelector('span'));
+      expect(container.textContent).toEqual('3');
+    });
+
+    it('should alway use option value', () => {
+      const Test: React.FC<Readonly<{ value?: number }>> = ({ value }) => {
+        const [mergedValue, setMergedValue] = usePropState<number>(
+          undefined,
+          value,
+        );
+        return (
+          <span
+            onClick={() => {
+              setMergedValue(12);
+            }}
+          >
+            {mergedValue}
+          </span>
+        );
+      };
+
+      const { container } = render(<Test value={1} />);
+      fireEvent.click(container.querySelector('span'));
+
+      expect(container.textContent).toBe('1');
+    });
+
+    it('render once', () => {
+      let count = 0;
+
+      const Demo: React.FC = () => {
+        const [] = usePropState(undefined);
         count += 1;
         return null;
       };

--- a/tests/hooks.test.tsx
+++ b/tests/hooks.test.tsx
@@ -8,7 +8,7 @@ import useMergedState from '../src/hooks/useMergedState';
 import useMobile from '../src/hooks/useMobile';
 import useState from '../src/hooks/useState';
 import useSyncState from '../src/hooks/useSyncState';
-import usePropState from '../src/hooks/usePropState';
+import useControlledState from '../src/hooks/useControlledState';
 
 global.disableUseId = false;
 
@@ -318,13 +318,16 @@ describe('hooks', () => {
     });
   });
 
-  describe('usePropState', () => {
+  describe('useControlledState', () => {
     const FC: React.FC<{
       value?: string;
       defaultValue?: string | (() => string);
     }> = props => {
       const { value, defaultValue } = props;
-      const [val, setVal] = usePropState<string>(defaultValue ?? null, value);
+      const [val, setVal] = useControlledState<string>(
+        defaultValue ?? null,
+        value,
+      );
       return (
         <>
           <input
@@ -367,7 +370,7 @@ describe('hooks', () => {
       let renderTimes = 0;
 
       const Test = () => {
-        const [val, setVal] = usePropState(0);
+        const [val, setVal] = useControlledState(0);
 
         React.useEffect(() => {
           renderTimes += 1;
@@ -385,7 +388,7 @@ describe('hooks', () => {
 
     it('React 18 should not reset to undefined', () => {
       const Demo = () => {
-        const [val] = usePropState(33, undefined);
+        const [val] = useControlledState(33, undefined);
 
         return <div>{val}</div>;
       };
@@ -401,7 +404,7 @@ describe('hooks', () => {
 
     it('uncontrolled to controlled', () => {
       const Demo: React.FC<Readonly<{ value?: number }>> = ({ value }) => {
-        const [mergedValue, setMergedValue] = usePropState<number>(
+        const [mergedValue, setMergedValue] = useControlledState<number>(
           () => 233,
           value,
         );
@@ -437,7 +440,7 @@ describe('hooks', () => {
 
     it('should alway use option value', () => {
       const Test: React.FC<Readonly<{ value?: number }>> = ({ value }) => {
-        const [mergedValue, setMergedValue] = usePropState<number>(
+        const [mergedValue, setMergedValue] = useControlledState<number>(
           undefined,
           value,
         );
@@ -462,7 +465,7 @@ describe('hooks', () => {
       let count = 0;
 
       const Demo: React.FC = () => {
-        const [] = usePropState(undefined);
+        const [] = useControlledState(undefined);
         count += 1;
         return null;
       };


### PR DESCRIPTION
* React 18 以后不需要去做防御性编程，`useState` 更新 unmount state 不再会有 warning。
* 移除了 `onChange` 和 `postState` 逻辑，代码中大部分情况都没有使用这两个特性但是却额外消耗了性能。

MAC M4 下，usePropState 会比 useMergedState 节约 ~0.01ms 性能。考虑到偏底层调度，对于 Table 嵌套子组件的场景会有一定客观的效果。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 新增用于统一受控/非受控状态管理的 React Hook，提升组件状态处理的灵活性与一致性。
- 文档
  - 为现有合并状态 Hook 添加弃用标注，并指引使用新的方案（在不需兼容旧环境时）。
- 测试
  - 增加全面的用例覆盖新 Hook，包括默认值、受控/非受控切换、严格模式下行为与渲染次数等场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->