### PR TITLE
fix: resolving first focus on elements is incorrect

### DIFF
--- a/src/Dom/focus.ts
+++ b/src/Dom/focus.ts
@@ -195,6 +195,11 @@ export function lockFocus(element: HTMLElement, id: string): VoidFunction {
     // Just add event since it will de-duplicate
     window.addEventListener('focusin', syncFocus);
     window.addEventListener('keydown', onWindowKeyDown, true);
+    // If the element is not focused, focus it
+    // https://github.com/ant-design/ant-design/issues/56963
+    if (!hasFocus(element)) {
+      element.focus({ preventScroll: true });
+    }
     syncFocus();
   }
 

--- a/src/Dom/focus.ts
+++ b/src/Dom/focus.ts
@@ -153,7 +153,11 @@ function syncFocus() {
 
     const matchElement = focusableList.includes(lastFocusElement as HTMLElement)
       ? lastFocusElement
-      : focusableList[0];
+      : // https://github.com/ant-design/ant-design/issues/56963
+        // lastElement may not be focusable, so we need to check if it is focusable and then focus it
+        focusable(lastElement)
+        ? lastElement
+        : focusableList[0];
 
     matchElement?.focus({ preventScroll: true });
   } else {
@@ -195,11 +199,6 @@ export function lockFocus(element: HTMLElement, id: string): VoidFunction {
     // Just add event since it will de-duplicate
     window.addEventListener('focusin', syncFocus);
     window.addEventListener('keydown', onWindowKeyDown, true);
-    // If the element is not focused, focus it
-    // https://github.com/ant-design/ant-design/issues/56963
-    if (!hasFocus(element)) {
-      element.focus({ preventScroll: true });
-    }
     syncFocus();
   }
 


### PR DESCRIPTION
问题点： `Modal`弹框首次`focus` 不正确，第二次才恢复正常行为

解决办法：在 `syncFocus` 时判断一下先当前元素是否已聚焦，如果没有的话进行聚焦操作，然后再使用兜底的逻辑聚焦到第一个可聚焦的子元素

fix https://github.com/ant-design/ant-design/issues/56963

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug修复**
  * 改进了恢复焦点逻辑，避免将焦点错误设置到不可聚焦的元素，提升焦点还原可靠性，并在聚焦时继续阻止页面滚动。
* **新增**
  * 新增可锁定焦点的公用接口，支持将焦点同步到目标元素或其首个可聚焦子项。
* **测试**
  * 添加了覆盖即时聚焦、已聚焦不重复聚焦与清理行为的单元测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->