### PR TITLE
fix: scrollbar measurement missing CSP nonce when creating <style>

### DIFF
--- a/src/getScrollBarSize.tsx
+++ b/src/getScrollBarSize.tsx
@@ -10,7 +10,7 @@ type ExtendCSSStyleDeclaration = CSSStyleDeclaration & {
 
 let cached: ScrollBarSize;
 
-function measureScrollbarSize(ele?: HTMLElement): ScrollBarSize {
+function measureScrollbarSize(ele?: HTMLElement, csp?: { nonce?: string }): ScrollBarSize {
   const randomId = `rc-scrollbar-measure-${Math.random()
     .toString(36)
     .substring(7)}`;
@@ -53,6 +53,7 @@ ${widthStyle}
 ${heightStyle}
 }`,
         randomId,
+        { csp },
       );
     } catch (e) {
       // Can't wrap, just log error
@@ -98,7 +99,7 @@ export default function getScrollBarSize(fresh?: boolean): number {
   return cached.width;
 }
 
-export function getTargetScrollBarSize(target: HTMLElement) {
+export function getTargetScrollBarSize(target: HTMLElement, csp?: { nonce?: string }) {
   if (
     typeof document === 'undefined' ||
     !target ||
@@ -107,5 +108,5 @@ export function getTargetScrollBarSize(target: HTMLElement) {
     return { width: 0, height: 0 };
   }
 
-  return measureScrollbarSize(target);
+  return measureScrollbarSize(target, csp);
 }

--- a/tests/getScrollBarSize.test.ts
+++ b/tests/getScrollBarSize.test.ts
@@ -47,5 +47,27 @@ describe('getScrollBarSize', () => {
         height: 0,
       });
     });
+
+    it('should pass csp nonce to updateCSS', () => {
+      const updateCSSSpy = jest.spyOn(
+        require('../src/Dom/dynamicCSS'),
+        'updateCSS',
+      );
+
+      const target = document.createElement('div');
+      document.body.appendChild(target);
+
+      const nonce = 'test-nonce-123';
+      getTargetScrollBarSize(target, { nonce });
+
+      expect(updateCSSSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        { csp: { nonce } },
+      );
+
+      updateCSSSpy.mockRestore();
+      document.body.removeChild(target);
+    });
   });
 });

--- a/tests/getScrollBarSize.test.ts
+++ b/tests/getScrollBarSize.test.ts
@@ -57,17 +57,19 @@ describe('getScrollBarSize', () => {
       const target = document.createElement('div');
       document.body.appendChild(target);
 
-      const nonce = 'test-nonce-123';
-      getTargetScrollBarSize(target, { nonce });
+      try {
+        const nonce = 'test-nonce-123';
+        getTargetScrollBarSize(target, { nonce });
 
-      expect(updateCSSSpy).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(String),
-        { csp: { nonce } },
-      );
-
-      updateCSSSpy.mockRestore();
-      document.body.removeChild(target);
+        expect(updateCSSSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.any(String),
+          { csp: { nonce } },
+        );
+      } finally {
+        updateCSSSpy.mockRestore();
+        document.body.removeChild(target);
+      }
     });
   });
 });


### PR DESCRIPTION
The CSP needs to be passed in by the calling component (via the ConfigContext or ConfigProvider), but these utility methods need to have a way to pass in this value, to be used when cloning the <style> element and calling `updateCSS()`.

I tried to add this in a way that would not break any of the callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 增强对 Content Security Policy (CSP) nonce 的支持：动态注入的滚动条样式现在可在启用 CSP nonce 的环境中正确应用，保持向后兼容，现有集成无需修改。
* **测试**
  * 新增单元测试以验证 CSP nonce 在动态样式注入时被正确传递和使用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->