### PR TITLE
feat(mergeProps): enhance mergeProps to handle className and style

### DIFF
--- a/src/mergeProps.ts
+++ b/src/mergeProps.ts
@@ -1,6 +1,11 @@
 /**
  * Merges multiple props objects into one. Unlike `Object.assign()` or `{ ...a, ...b }`, it skips
  * properties whose value is explicitly set to `undefined`.
+ *
+ * @example
+ * ```ts
+ * const { a, b } = mergeProps(defaults, config, props);
+ * ```
  */
 function mergeProps<A, B>(a: A, b: B): B & A;
 function mergeProps<A, B, C>(a: A, b: B, c: C): C & B & A;
@@ -11,7 +16,13 @@ function mergeProps(...items: any[]) {
     if (item) {
       for (const key of Object.keys(item)) {
         if (item[key] !== undefined) {
-          ret[key] = item[key];
+          if (key === 'className') {
+            ret[key] = ret[key] ? `${ret[key]} ${item[key]}` : item[key];
+          } else if (key === 'style') {
+            ret[key] = { ...ret[key], ...item[key] };
+          } else {
+            ret[key] = item[key];
+          }
         }
       }
     }

--- a/src/mergeProps.ts
+++ b/src/mergeProps.ts
@@ -17,7 +17,7 @@ function mergeProps(...items: any[]) {
       for (const key of Object.keys(item)) {
         if (item[key] !== undefined) {
           if (key === 'className') {
-            ret[key] = ret[key] ? `${ret[key]} ${item[key]}` : item[key];
+            ret[key] = `${ret[key] || ''} ${item[key] || ''}`.trim();
           } else if (key === 'style') {
             ret[key] = { ...ret[key], ...item[key] };
           } else {

--- a/tests/mergeProps.test.ts
+++ b/tests/mergeProps.test.ts
@@ -7,20 +7,6 @@ describe('mergeProps', () => {
     expect(mergeProps(a, b)).toEqual({ foo: 1, bar: 3, baz: 4 });
   });
 
-  it('merges className', () => {
-    const a = { className: 'a' };
-    const b = { className: 'b' };
-    expect(mergeProps(a, b)).toEqual({ className: 'a b' });
-  });
-
-  it('merges style', () => {
-    const a = { style: { color: 'red' } };
-    const b = { style: { backgroundColor: 'blue' } };
-    expect(mergeProps(a, b)).toEqual({
-      style: { color: 'red', backgroundColor: 'blue' },
-    });
-  });
-
   it('excludes keys with undefined values', () => {
     const a = { foo: 1, bar: undefined };
     const b = { bar: 2 };
@@ -62,5 +48,83 @@ describe('mergeProps', () => {
 
   it('handles empty objects', () => {
     expect(mergeProps({}, { a: 1 }, {})).toEqual({ a: 1 });
+  });
+
+  describe('className', () => {
+    it('merges strings', () => {
+      const a = { className: 'a' };
+      const b = { className: 'b' };
+      expect(mergeProps(a, b)).toEqual({ className: 'a b' });
+    });
+
+    it('keeps previous when later is undefined', () => {
+      expect(mergeProps({ className: 'a' }, { className: undefined })).toEqual({
+        className: 'a',
+      });
+    });
+
+    it('omits key when only undefined', () => {
+      expect(
+        (mergeProps as (...items: any[]) => any)({ className: undefined }),
+      ).toEqual({});
+    });
+
+    it('null merges like empty string', () => {
+      expect(
+        mergeProps({ className: 'a' }, { className: null as any }),
+      ).toEqual({ className: 'a' });
+      expect(
+        mergeProps({ className: null as any }, { className: 'b' }),
+      ).toEqual({ className: 'b' });
+      expect(
+        (mergeProps as (...items: any[]) => any)({ className: null as any }),
+      ).toEqual({ className: '' });
+    });
+  });
+
+  describe('style', () => {
+    it('merges objects', () => {
+      const a = { style: { color: 'red' } };
+      const b = { style: { backgroundColor: 'blue' } };
+      expect(mergeProps(a, b)).toEqual({
+        style: { color: 'red', backgroundColor: 'blue' },
+      });
+    });
+
+    it('keeps previous when later is undefined', () => {
+      expect(
+        mergeProps({ style: { color: 'red' } }, { style: undefined }),
+      ).toEqual({ style: { color: 'red' } });
+    });
+
+    it('null source does not wipe previous style', () => {
+      expect(
+        mergeProps({ style: { color: 'red' } }, { style: null as any }),
+      ).toEqual({ style: { color: 'red' } });
+    });
+
+    it('applies when earlier style is undefined or null', () => {
+      expect(
+        mergeProps({ style: undefined }, { style: { color: 'red' } }),
+      ).toEqual({ style: { color: 'red' } });
+      expect(
+        mergeProps({ style: null as any }, { style: { color: 'red' } }),
+      ).toEqual({ style: { color: 'red' } });
+    });
+
+    it('nested properties may be null or undefined', () => {
+      expect(
+        mergeProps(
+          { style: { color: 'red', margin: undefined as any } },
+          { style: { padding: null as any, color: 'blue' } },
+        ),
+      ).toEqual({
+        style: {
+          color: 'blue',
+          margin: undefined,
+          padding: null,
+        },
+      });
+    });
   });
 });

--- a/tests/mergeProps.test.ts
+++ b/tests/mergeProps.test.ts
@@ -7,6 +7,20 @@ describe('mergeProps', () => {
     expect(mergeProps(a, b)).toEqual({ foo: 1, bar: 3, baz: 4 });
   });
 
+  it('merges className', () => {
+    const a = { className: 'a' };
+    const b = { className: 'b' };
+    expect(mergeProps(a, b)).toEqual({ className: 'a b' });
+  });
+
+  it('merges style', () => {
+    const a = { style: { color: 'red' } };
+    const b = { style: { backgroundColor: 'blue' } };
+    expect(mergeProps(a, b)).toEqual({
+      style: { color: 'red', backgroundColor: 'blue' },
+    });
+  });
+
   it('excludes keys with undefined values', () => {
     const a = { foo: 1, bar: undefined };
     const b = { bar: 2 };

--- a/tests/mergeProps.test.ts
+++ b/tests/mergeProps.test.ts
@@ -80,6 +80,30 @@ describe('mergeProps', () => {
         (mergeProps as (...items: any[]) => any)({ className: null as any }),
       ).toEqual({ className: '' });
     });
+
+    it('empty string className', () => {
+      expect(mergeProps({ className: 'a' }, { className: '' })).toEqual({
+        className: 'a',
+      });
+      expect(mergeProps({ className: '' }, { className: 'b' })).toEqual({
+        className: 'b',
+      });
+      expect(
+        (mergeProps as (...items: any[]) => any)({ className: '' }),
+      ).toEqual({ className: '' });
+    });
+
+    it('whitespace-only className is trimmed', () => {
+      expect(mergeProps({ className: 'a' }, { className: ' ' })).toEqual({
+        className: 'a',
+      });
+      expect(mergeProps({ className: ' ' }, { className: 'b' })).toEqual({
+        className: 'b',
+      });
+      expect(
+        (mergeProps as (...items: any[]) => any)({ className: ' ' }),
+      ).toEqual({ className: '' });
+    });
   });
 
   describe('style', () => {


### PR DESCRIPTION
className 和 style 是所有 antd 组件都支持的的 config，他们的 merge 规则和普通属性不同，这里做特殊处理，以减少 antd 中的重复代码逻辑。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进属性合并：className 对字符串进行空格连接（trim 后合并），null 视为空字符串，后续为 undefined 时保留先前值；style 进行浅合并（属性级覆盖）而非整体替换，后续为 undefined/null 不会错误擦除先前样式，允许嵌套属性为 undefined/null。

* **Tests**
  * 添加 className 连接、空白/undefined/null 行为的测试用例
  * 添加 style 浅合并、保留/覆盖及嵌套属性行为的测试用例
<!-- end of auto-generated comment: release notes by coderabbit.ai -->