### PR TITLE
[codex] fix useLockFocus retry when element is filled later

### DIFF
--- a/src/Dom/focus.ts
+++ b/src/Dom/focus.ts
@@ -1,4 +1,5 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import type { DependencyList } from 'react';
 import isVisible from './isVisible';
 import useId from '../hooks/useId';
 
@@ -212,6 +213,41 @@ export function lockFocus(element: HTMLElement, id: string): VoidFunction {
 }
 
 /**
+ * Retry an effect until it reports ready.
+ * When `ready` is `false`, it will schedule one more effect cycle and call `func` again
+ * with the next `retryTimes`.
+ */
+type RetryEffectResult = readonly [
+  clearFunc: VoidFunction | undefined,
+  ready: boolean,
+];
+
+function useRetryEffect(
+  func: (retryTimes: number) => RetryEffectResult,
+  deps: DependencyList,
+): void {
+  /* eslint-disable react-hooks/exhaustive-deps */
+  const retryTimesRef = useRef(0);
+  const [retryMark, setRetryMark] = useState(0);
+
+  useEffect(() => {
+    retryTimesRef.current = 0;
+  }, deps);
+
+  useEffect(() => {
+    const [clearFn, ready] = func(retryTimesRef.current);
+
+    if (!ready) {
+      retryTimesRef.current += 1;
+      setRetryMark(count => count + 1);
+    }
+
+    return clearFn;
+  }, [...deps, retryMark]);
+  /* eslint-enable react-hooks/exhaustive-deps */
+}
+
+/**
  * Lock focus within an element.
  * When locked, focus will be restricted to focusable elements within the specified element.
  * If multiple elements are locked, only the last locked element will be effective.
@@ -222,15 +258,24 @@ export function useLockFocus(
   getElement: () => HTMLElement | null,
 ): [ignoreElement: (ele: HTMLElement) => void] {
   const id = useId();
+  const getElementRef = useRef(getElement);
 
-  useEffect(() => {
-    if (lock) {
-      const element = getElement();
-      if (element) {
-        return lockFocus(element, id);
-      }
+  getElementRef.current = getElement;
+
+  const lockEffect = (retryTimes: number): RetryEffectResult => {
+    if (!lock) {
+      return [undefined, true];
     }
-  }, [lock, id]);
+
+    const element = getElementRef.current();
+    if (element) {
+      return [lockFocus(element, id), true];
+    }
+
+    return [undefined, retryTimes >= 1];
+  };
+
+  useRetryEffect(lockEffect, [id, lock]);
 
   const ignoreElement = (ele: HTMLElement) => {
     if (ele) {

--- a/tests/focus.test.tsx
+++ b/tests/focus.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
-import React, { useRef } from 'react';
-import { render } from '@testing-library/react';
+import React, { useEffect, useRef, useState } from 'react';
+import { render, waitFor } from '@testing-library/react';
 import { spyElementPrototype } from '../src/test/domHook';
 import { getFocusNodeList, triggerFocus, useLockFocus } from '../src/Dom/focus';
 
@@ -94,6 +94,39 @@ describe('focus', () => {
       const outerButton = getByTestId('outer-button') as HTMLButtonElement;
       outerButton.focus();
       expect(document.activeElement).toBe(input1);
+    });
+
+    it('should retry lock once when element is filled after lock starts', async () => {
+      const DelayedElementComponent: React.FC = () => {
+        const elementRef = useRef<HTMLDivElement>(null);
+        const [element, setElement] = useState<HTMLDivElement | null>(null);
+
+        useLockFocus(true, () => element);
+
+        useEffect(() => {
+          setElement(elementRef.current);
+        }, []);
+
+        return (
+          <>
+            <button data-testid="outer-button">Outer</button>
+            <div ref={elementRef} data-testid="focus-container" tabIndex={0}>
+              <input key="input1" data-testid="input1" />
+              <button key="button1" data-testid="button1">
+                Button
+              </button>
+            </div>
+          </>
+        );
+      };
+
+      const { getByTestId } = render(<DelayedElementComponent />);
+
+      const focusContainer = getByTestId('focus-container');
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(focusContainer);
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- add a small `useRetryEffect` helper in `src/Dom/focus.ts` to retry an effect until a late-filled element becomes available
- update `useLockFocus` to use that retry flow so locking still starts when the target ref is populated via a later state update
- add a regression test covering the delayed element case

## Why
`useLockFocus` previously only retried when `[lock, id]` changed. If the target element was filled by a later state update, the initial effect could miss the element and never lock focus.

## Impact
Components that provide the lock target through a state-backed ref now still get focus locking after the element appears.

## Validation
- `npx tsc --noEmit`
- `npx eslint src/Dom/focus.ts tests/focus.test.tsx`
- `npm test -- tests/focus.test.tsx --runInBand`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 改进了焦点管理的可靠性，确保在DOM元素延迟加载或动态渲染时，焦点锁定能够正确执行。

* **测试**
  * 添加了新的测试用例，验证动态元素加载场景下的焦点锁定行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->