### PR TITLE
fix: getNodeRef should not fallback to element.ref in React 19

### DIFF
--- a/src/ref.ts
+++ b/src/ref.ts
@@ -90,17 +90,19 @@ export const supportNodeRef = <T = any>(
 /**
  * In React 19. `ref` is not a property from node.
  * But a property from `props.ref`.
- * To check if `props.ref` exist or fallback to `ref`.
+ * In < React 19, `ref` lives on the element itself (`element.ref`).
  */
 export const getNodeRef: <T = any>(
   node: React.ReactNode,
 ) => React.Ref<T> | null = node => {
   if (node && isReactElement(node)) {
     const ele = node as any;
-
-    // Source from:
-    // https://github.com/mui/material-ui/blob/master/packages/mui-utils/src/getReactNodeRef/getReactNodeRef.ts
-    return ele.props.propertyIsEnumerable('ref') ? ele.props.ref : ele.ref;
+    // React 19: `ref` is a regular prop and reading `element.ref` triggers a
+    // deprecation warning, even when the prop is absent. Branch on the React
+    // major version to avoid touching `element.ref` on React 19+.
+    return ReactMajorVersion >= 19
+      ? (ele.props.ref ?? null)
+      : ele.ref;
   }
   return null;
 };

--- a/src/ref.ts
+++ b/src/ref.ts
@@ -102,7 +102,7 @@ export const getNodeRef: <T = any>(
     // major version to avoid touching `element.ref` on React 19+.
     return ReactMajorVersion >= 19
       ? (ele.props.ref ?? null)
-      : ele.ref;
+      : (ele.ref ?? null);
   }
   return null;
 };

--- a/tests/ref-19.test.tsx
+++ b/tests/ref-19.test.tsx
@@ -44,6 +44,16 @@ describe('ref: React 19', () => {
     expect(errSpy).not.toHaveBeenCalled();
   });
 
+  it('getNodeRef on element without ref does not access element.ref', () => {
+    // Regression: previous propertyIsEnumerable('ref') check fell back to
+    // `element.ref` for elements rendered without an explicit ref prop, which
+    // triggers React 19's "Accessing element.ref was removed" warning.
+    const node = <div className="no-ref" />;
+
+    expect(getNodeRef(node)).toBeNull();
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
   it('useComposeRef', () => {
     const Demo: React.FC<React.PropsWithChildren> = ({ children }) => {
       const ref = React.useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary

`getNodeRef` currently triggers React 19's `Accessing element.ref was removed in React 19` warning for any element rendered **without** an explicit `ref` prop.

### Root cause

The current implementation (introduced in #593, replacing the original version-based branch from #545):

```ts
return ele.props.propertyIsEnumerable('ref') ? ele.props.ref : ele.ref;
```

`propertyIsEnumerable('ref')` returns `false` when the rendered JSX does not pass a `ref`, so the code falls through to `ele.ref`. Reading `element.ref` is exactly what React 19 deprecated.

This means the warning fires for **every** consumer of `getNodeRef` whose children may or may not carry a ref — for example `rc-dialog`, `rc-drawer`, and downstream components like antd's `<Modal />` / `<Drawer />`.

### Fix

Restore the version-based branch that PR #545 originally used. On React 19+ read `props.ref`; on older React keep reading `element.ref`. `ReactMajorVersion` is already declared at the top of the file (used by `supportRef`), so the change is local and minimal.

```ts
return ReactMajorVersion >= 19 ? (ele.props.ref ?? null) : ele.ref;
```

### Repro

Any element passed through `getNodeRef` without a ref prop:

```tsx
import { getNodeRef } from 'rc-util/lib/ref';

const node = <div />;
getNodeRef(node);
// → console: "Accessing element.ref was removed in React 19. ref is now a regular prop."
```

In real apps this surfaces every time a `<Modal>` / `<Drawer>` / `<Dialog>` is rendered with children that don't forward refs.

### Test

Added a regression test in `tests/ref-19.test.tsx` that:
- renders a `<div />` without a ref
- asserts `getNodeRef(node)` returns `null`
- asserts `console.error` was not called

The existing `it('getNodeRef')` test is unchanged.

### Related

- Regression of refactor in #593
- Closes the runtime warning observed in ant-design/ant-design#49267, ant-design/ant-design#51986, ant-design/ant-design#51458 (all closed without fix)

---

## 中文摘要

`getNodeRef` 在 React 19 下会对**没有传 `ref` prop 的元素**触发 `Accessing element.ref was removed in React 19` 警告。

### 根因

当前实现（来自 #593，覆盖了 #545 引入时的版本分支判断）：

```ts
return ele.props.propertyIsEnumerable('ref') ? ele.props.ref : ele.ref;
```

`propertyIsEnumerable('ref')` 在 JSX 没传 `ref` 时返回 `false`，于是 fallback 读 `ele.ref` —— 而 `element.ref` 正是 React 19 标记为 deprecated 的访问点。

这导致所有使用 `getNodeRef` 的组件（`rc-dialog` / `rc-drawer` / antd `<Modal />` / `<Drawer />` 等）只要 children 不显式带 ref，控制台就会冒红字。

### 修法

把分支逻辑回退到 #545 引入时的"按 React 版本判断"。文件顶部已有的 `ReactMajorVersion` 直接复用，改动只有这一处。

```ts
return ReactMajorVersion >= 19 ? (ele.props.ref ?? null) : ele.ref;
```

### 测试

`tests/ref-19.test.tsx` 增加一条回归测试：
- 渲染 `<div />`（不传 ref）
- 断言 `getNodeRef(node)` 返回 `null`
- 断言 `console.error` 没被调用


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了与 React 19 的兼容性，避免在无显式 ref 的元素上触发弃用/访问警告，并确保在此类情况下返回 null。

* **Tests**
  * 新增回归测试，验证在 React 19 场景下不会触发控制台错误且行为保持稳定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->