### PR TITLE
[codex] expose additional utilities from package entry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,50 @@
 export { default as useEvent } from './hooks/useEvent';
 export { default as useMergedState } from './hooks/useMergedState';
 export { default as useControlledState } from './hooks/useControlledState';
-export { supportNodeRef, supportRef, useComposeRef } from './ref';
-export { default as get } from './utils/get';
-export { default as set, merge, mergeWith } from './utils/set';
-export { default as warning, noteOnce } from './warning';
+export { default as useId, getId } from './hooks/useId';
+export {
+  default as useLayoutEffect,
+  useLayoutUpdateEffect,
+} from './hooks/useLayoutEffect';
+export { default as useMemo } from './hooks/useMemo';
+export { default as useState } from './hooks/useState';
+export { default as useSyncState } from './hooks/useSyncState';
+
+export {
+  composeRef,
+  fillRef,
+  getNodeRef,
+  supportNodeRef,
+  supportRef,
+  useComposeRef,
+} from './ref';
+
+export { default as canUseDom } from './Dom/canUseDom';
+export { default as contains } from './Dom/contains';
+export { removeCSS, updateCSS } from './Dom/dynamicCSS';
+export { getDOM, isDOM } from './Dom/findDOMNode';
+export { getFocusNodeList, triggerFocus, useLockFocus } from './Dom/focus';
+export type { InputFocusOptions } from './Dom/focus';
+export { default as isVisible } from './Dom/isVisible';
+export { getShadowRoot } from './Dom/shadow';
+
+export { default as KeyCode } from './KeyCode';
+export {
+  default as getScrollBarSize,
+  getTargetScrollBarSize,
+} from './getScrollBarSize';
+export { default as isEqual } from './isEqual';
+export { default as isMobile } from './isMobile';
 export { default as omit } from './omit';
+export { default as pickAttrs } from './pickAttrs';
+export { default as proxyObject } from './proxyObject';
+export { default as raf } from './raf';
 export { default as toArray } from './Children/toArray';
 export { default as mergeProps } from './mergeProps';
+
+export { default as get } from './utils/get';
+export { default as set, merge, mergeWith } from './utils/set';
+
+export { default as warning, noteOnce } from './warning';
+
+export type { GetContainer } from './PortalWrapper';

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,9 +21,14 @@ export {
 
 export { default as canUseDom } from './Dom/canUseDom';
 export { default as contains } from './Dom/contains';
-export { removeCSS, updateCSS } from './Dom/dynamicCSS';
+export { injectCSS, removeCSS, updateCSS } from './Dom/dynamicCSS';
 export { getDOM, isDOM } from './Dom/findDOMNode';
-export { getFocusNodeList, triggerFocus, useLockFocus } from './Dom/focus';
+export {
+  getFocusNodeList,
+  lockFocus,
+  triggerFocus,
+  useLockFocus,
+} from './Dom/focus';
 export type { InputFocusOptions } from './Dom/focus';
 export { default as isVisible } from './Dom/isVisible';
 export { getShadowRoot } from './Dom/shadow';


### PR DESCRIPTION
## Summary

- Export additional hooks, DOM helpers, ref utilities, and common utilities from the package entry.
- Export `InputFocusOptions` and `GetContainer` types from the root entry.

## Impact

Consumers can import these shared utilities directly from `@rc-component/util` instead of relying on deep import paths.

## Validation

- `npm run lint` (passes with 2 existing warnings in `src/Dom/findDOMNode.ts` and `src/Portal.tsx`)
- `npm test -- --runInBand`
- `npm run compile` (passes with the same existing warnings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 扩展公共 API 导出，新增多种 React Hook 支持以便更灵活的状态与副作用管理
  * 增强 DOM 与样式管理工具（动态样式注入/更新/移除、DOM 检测等）
  * 新增焦点控制与可见性/阴影 DOM 支持，改善无障碍与交互体验
  * 丰富引用工具集合与通用实用工具（键盘码、滚动条检测、移动设备识别等）

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/util/pull/761)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->