### PR TITLE
fix: avoid stale async unmount clearing latest React root

### DIFF
--- a/src/React/render.ts
+++ b/src/React/render.ts
@@ -11,17 +11,17 @@ type ContainerType = (Element | DocumentFragment) & {
   [MARK_ID]?: number;
 };
 
-export function render(node: React.ReactElement, container: ContainerType) {
+export const render = (node: React.ReactElement, container: ContainerType) => {
   const root = container[MARK] || createRoot(container);
 
   root.render(node);
 
   container[MARK] = root;
   container[MARK_ID] = (container[MARK_ID] || 0) + 1;
-}
+};
 
 // ========================= Unmount ==========================
-export async function unmount(container: ContainerType) {
+export const unmount = async (container: ContainerType) => {
   const root = container[MARK];
   const rootId = container[MARK_ID];
   // Delay to unmount to avoid React 18 sync warning
@@ -32,4 +32,4 @@ export async function unmount(container: ContainerType) {
       delete container[MARK_ID];
     }
   });
-}
+};

--- a/src/React/render.ts
+++ b/src/React/render.ts
@@ -3,10 +3,12 @@ import { createRoot } from 'react-dom/client';
 import type { Root } from 'react-dom/client';
 
 const MARK = '__rc_react_root__';
+const MARK_ID = '__rc_react_root_id__';
 
 // ========================== Render ==========================
 type ContainerType = (Element | DocumentFragment) & {
   [MARK]?: Root;
+  [MARK_ID]?: number;
 };
 
 export function render(node: React.ReactElement, container: ContainerType) {
@@ -15,14 +17,19 @@ export function render(node: React.ReactElement, container: ContainerType) {
   root.render(node);
 
   container[MARK] = root;
+  container[MARK_ID] = (container[MARK_ID] || 0) + 1;
 }
 
 // ========================= Unmount ==========================
 export async function unmount(container: ContainerType) {
+  const root = container[MARK];
+  const rootId = container[MARK_ID];
   // Delay to unmount to avoid React 18 sync warning
   return Promise.resolve().then(() => {
-    container[MARK]?.unmount();
-
-    delete container[MARK];
+    if (container[MARK] === root && container[MARK_ID] === rootId) {
+      root?.unmount();
+      delete container[MARK];
+      delete container[MARK_ID];
+    }
   });
 }


### PR DESCRIPTION
增加 MARK_ID，避免 unmount() 的微任务延迟把后续重新 render 的 root 误删。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 优化了 React 组件的挂载和卸载流程，添加了实例追踪机制。现在应用能够更准确地识别和处理组件状态，防止在快速连续操作中出现过期的异步卸载问题，显著提高应用的稳定性和可靠性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/util/pull/763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->