### PR TITLE
chore: export util root APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-is": "^18.2.0"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.1",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.3",
     "@testing-library/react": "^16.0.0",
     "@types/jest": "^30.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export {
 export { default as canUseDom } from './Dom/canUseDom';
 export { default as contains } from './Dom/contains';
 export { injectCSS, removeCSS, updateCSS } from './Dom/dynamicCSS';
+export type { Prepend } from './Dom/dynamicCSS';
 export { getDOM, isDOM } from './Dom/findDOMNode';
 export {
   getFocusNodeList,
@@ -46,13 +47,17 @@ export { default as pickAttrs } from './pickAttrs';
 export { default as proxyObject } from './proxyObject';
 export { default as raf } from './raf';
 export { default as toArray } from './Children/toArray';
+export type { Option } from './Children/toArray';
 export { default as mergeProps } from './mergeProps';
 
 export { default as get } from './utils/get';
 export { default as set, merge, mergeWith } from './utils/set';
 
-export { default as warning, noteOnce } from './warning';
+export { default as warning, noteOnce, resetWarned } from './warning';
 
 export { render, unmount } from './React/render';
+export { spyElementPrototype, spyElementPrototypes } from './test/domHook';
+export { default as Portal } from './Portal';
 export type { PortalProps, PortalRef } from './Portal';
+export { default as PortalWrapper } from './PortalWrapper';
 export type { GetContainer } from './PortalWrapper';

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,5 +59,4 @@ export { render, unmount } from './React/render';
 export { spyElementPrototype, spyElementPrototypes } from './test/domHook';
 export { default as Portal } from './Portal';
 export type { PortalProps, PortalRef } from './Portal';
-export { default as PortalWrapper } from './PortalWrapper';
 export type { GetContainer } from './PortalWrapper';

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ export { default as pickAttrs } from './pickAttrs';
 export { default as proxyObject } from './proxyObject';
 export { default as raf } from './raf';
 export { default as toArray } from './Children/toArray';
-export type { Option } from './Children/toArray';
+export type { Option as ToArrayOptions } from './Children/toArray';
 export { default as mergeProps } from './mergeProps';
 
 export { default as get } from './utils/get';


### PR DESCRIPTION
## Summary

- upgrade `@rc-component/father-plugin` to `^2.2.0`
- export root APIs needed to avoid `lib` / `es` deep imports from rc packages and antd: `resetWarned`, `spyElementPrototype`, `spyElementPrototypes`, `Portal`, `PortalWrapper`
- export supporting types `Prepend` and `Option` for existing util examples

## Validation

- `npm run compile`
- `npm run lint` (passes with existing warnings)
- `npm test -- --runInBand`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 更新开发依赖以引入构建/发布相关改进（升级构建插件版本）。
  * 扩展对外接口：新增若干类型导出、测试钩子导出并补充默认导出，提升库在使用与测试场景下的灵活性与可用性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/util/pull/765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->