### PR TITLE
chore: standardize repository tooling

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -16,6 +16,6 @@ export default defineConfig({
   base: basePath,
   publicPath,
   alias: {
-    'rc-util/es': path.resolve(__dirname, 'src'),
+    '@rc-component/util/es': path.resolve(__dirname, 'src'),
   },
 });

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: ant-design
+open_collective: ant-design

--- a/.github/workflows/cloudflare-pages-preview.yml
+++ b/.github/workflows/cloudflare-pages-preview.yml
@@ -1,0 +1,42 @@
+name: Cloudflare Pages Preview
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+      PREVIEW: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - name: Skip Cloudflare Pages preview
+        if: ${{ env.CLOUDFLARE_API_TOKEN == '' || env.CLOUDFLARE_ACCOUNT_ID == '' || env.CLOUDFLARE_PAGES_PROJECT == '' }}
+        run: echo "Cloudflare Pages preview is not configured; skip deployment."
+      - name: Install dependencies
+        if: ${{ env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != '' && env.CLOUDFLARE_PAGES_PROJECT != '' }}
+        run: npm install
+      - name: Build site
+        if: ${{ env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != '' && env.CLOUDFLARE_PAGES_PROJECT != '' }}
+        run: npm run build
+      - name: Deploy preview
+        if: ${{ env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != '' && env.CLOUDFLARE_PAGES_PROJECT != '' }}
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0
+        with:
+          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy .doc --project-name=${{ env.CLOUDFLARE_PAGES_PROJECT }} --branch=${{ github.head_ref }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,12 @@
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ['master']
   pull_request:
-    branches: [ "master" ]
+    branches: ['master']
   schedule:
-    - cron: "4 6 * * 0"
+    - cron: '4 6 * * 0'
 
 jobs:
   analyze:
@@ -20,22 +20,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ javascript ]
+        language: [javascript]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
         with:
-          category: "/language:${{ matrix.language }}"
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,15 +29,15 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        uses: github/codeql-action/init@411bbbe57033eedfc1a82d68c01345aa96c737d7
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        uses: github/codeql-action/autobuild@411bbbe57033eedfc1a82d68c01345aa96c737d7
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        uses: github/codeql-action/analyze@411bbbe57033eedfc1a82d68c01345aa96c737d7
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/react-component-ci.yml
+++ b/.github/workflows/react-component-ci.yml
@@ -2,5 +2,5 @@ name: ✅ test
 on: [push, pull_request]
 jobs:
   test:
-    uses: react-component/rc-test/.github/workflows/test-npm.yml@main
+    uses: react-component/rc-test/.github/workflows/test-utoo.yml@main
     secrets: inherit

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,0 +1,27 @@
+name: React Doctor
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write
+
+concurrency:
+  group: react-doctor-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  react-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: millionco/react-doctor@0b4f4f4bd248a154e64eb508a48347f71154b3f3

--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -13,10 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
 
       - name: setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 20
 
@@ -30,7 +32,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@329bcc8f12caed2cefe5a5b80781499a6f3b361b
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./.doc

--- a/.github/workflows/surge-preview.yml
+++ b/.github/workflows/surge-preview.yml
@@ -1,0 +1,39 @@
+name: Surge Preview
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  statuses: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    env:
+      SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+      PREVIEW: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - uses: afc163/surge-preview@bf90a5a86111f6311ca42f0a5a0f80fb0fb03cec
+        if: ${{ env.SURGE_TOKEN != '' }}
+        with:
+          surge_token: ${{ env.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dist: .doc
+          failOnError: true
+          setCommitStatus: true
+          build: |
+            npm install
+            npm run build
+      - name: Skip Surge preview
+        if: ${{ env.SURGE_TOKEN == '' }}
+        run: echo "SURGE_TOKEN is not configured; skip Surge preview."

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 - React 18+ compatible helpers used by rc-component packages.
 - Ref composition, React 19 ref compatibility checks, and portal helpers.
 - DOM helpers for focus management, dynamic styles, visibility, shadow roots, and scrollbar measurement.
-- Hooks for controlled state, layout effects, stable callbacks, memo comparison, ids, and mobile detection.
+- Hooks for controlled state, layout effects, stable callbacks, memo comparison, and ids.
 - Small data utilities for object paths, shallow props merging, omission, equality checks, and child flattening.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -1,303 +1,168 @@
-# rc-util
+<div align="center">
+  <h1>@rc-component/util</h1>
+  <p>🧰 Common React utilities shared across rc-component packages.</p>
 
-Common Utils For React Component.
+  <a href="https://ant.design">
+    <img width="32" height="32" src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg" alt="Ant Design" />
+  </a>
 
-[![NPM version][npm-image]][npm-url]
-[![npm download][download-image]][download-url]
-[![build status][github-actions-image]][github-actions-url]
-[![Codecov][codecov-image]][codecov-url]
-[![bundle size][bundlephobia-image]][bundlephobia-url]
-[![dumi][dumi-image]][dumi-url]
+  <p>Part of the Ant Design ecosystem.</p>
 
-[npm-image]: http://img.shields.io/npm/v/rc-util.svg?style=flat-square
-[npm-url]: http://npmjs.org/package/rc-util
-[travis-image]: https://img.shields.io/travis/react-component/util/master?style=flat-square
-[travis-url]: https://travis-ci.com/react-component/util
+[![NPM version][npm-image]][npm-url] [![npm download][download-image]][download-url] [![build status][github-actions-image]][github-actions-url] [![Codecov][codecov-image]][codecov-url] [![bundle size][bundlephobia-image]][bundlephobia-url] [![dumi][dumi-image]][dumi-url]
+
+</div>
+
+[npm-image]: https://img.shields.io/npm/v/@rc-component/util.svg?style=flat-square
+[npm-url]: https://npmjs.org/package/@rc-component/util
 [github-actions-image]: https://github.com/react-component/util/actions/workflows/react-component-ci.yml/badge.svg
 [github-actions-url]: https://github.com/react-component/util/actions/workflows/react-component-ci.yml
 [codecov-image]: https://img.shields.io/codecov/c/github/react-component/util/master.svg?style=flat-square
 [codecov-url]: https://app.codecov.io/gh/react-component/util
-[david-url]: https://david-dm.org/react-component/util
-[david-image]: https://david-dm.org/react-component/util/status.svg?style=flat-square
-[david-dev-url]: https://david-dm.org/react-component/util?type=dev
-[david-dev-image]: https://david-dm.org/react-component/util/dev-status.svg?style=flat-square
-[download-image]: https://img.shields.io/npm/dm/rc-util.svg?style=flat-square
-[download-url]: https://npmjs.org/package/rc-util
-[bundlephobia-url]: https://bundlephobia.com/package/rc-util
-[bundlephobia-image]: https://badgen.net/bundlephobia/minzip/rc-util
-[dumi-url]: https://github.com/umijs/dumi
+[download-image]: https://img.shields.io/npm/dm/@rc-component/util.svg?style=flat-square
+[download-url]: https://npmjs.org/package/@rc-component/util
+[bundlephobia-image]: https://img.shields.io/bundlephobia/minzip/%40rc-component%2Futil?style=flat-square
+[bundlephobia-url]: https://bundlephobia.com/package/@rc-component/util
 [dumi-image]: https://img.shields.io/badge/docs%20by-dumi-blue?style=flat-square
+[dumi-url]: https://github.com/umijs/dumi
+
+## Highlights
+
+- React 18+ compatible helpers used by rc-component packages.
+- Ref composition, React 19 ref compatibility checks, and portal helpers.
+- DOM helpers for focus management, dynamic styles, visibility, shadow roots, and scrollbar measurement.
+- Hooks for controlled state, layout effects, stable callbacks, memo comparison, ids, and mobile detection.
+- Small data utilities for object paths, shallow props merging, omission, equality checks, and child flattening.
 
 ## Install
 
-[![rc-util](https://nodei.co/npm/rc-util.png)](https://npmjs.org/package/rc-util)
+```bash
+npm install @rc-component/util
+```
+
+## Usage
+
+```tsx | pure
+import { useMergedState, warning } from '@rc-component/util';
+
+export default function Demo() {
+  const [open, setOpen] = useMergedState(false, {
+    onChange: nextOpen => {
+      warning(typeof nextOpen === 'boolean', '`open` should be boolean.');
+    },
+  });
+
+  return (
+    <button type="button" onClick={() => setOpen(!open)}>
+      {open ? 'Close' : 'Open'}
+    </button>
+  );
+}
+```
+
+Deep imports are also available when a package needs a single helper:
+
+```ts | pure
+import Portal from '@rc-component/util/es/Portal';
+import { composeRef } from '@rc-component/util/es/ref';
+import KeyCode from '@rc-component/util/es/KeyCode';
+```
+
+New code should prefer `@rc-component/util`. Legacy projects may still contain `rc-util` imports while they migrate to the scoped package.
+
+## Examples
+
+```bash
+npm install
+npm start
+```
+
+Then open <http://localhost:8000/>.
 
 ## API
 
-### createChainedFunction
+### Hooks
 
-> (...functions): Function
+| Export                                     | Description                                                                                            |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `useControlledState`                       | Controlled/uncontrolled state helper for React 18+ projects.                                           |
+| `useMergedState`                           | Legacy controlled/uncontrolled state helper with `defaultValue`, `value`, `onChange`, and `postState`. |
+| `useEvent`                                 | Stable callback wrapper that always calls the latest handler.                                          |
+| `useLayoutEffect`, `useLayoutUpdateEffect` | Layout effect helpers with server-side rendering guards.                                               |
+| `useMemo`                                  | Memo helper with a custom comparison function.                                                         |
+| `useState`                                 | State helper that can ignore updates after destroy.                                                    |
+| `useSyncState`                             | Synchronous state getter and updater pair.                                                             |
+| `useId`, `getId`                           | Stable id helpers.                                                                                     |
+| `useMobile`                                | Mobile environment detection hook.                                                                     |
 
-Create a function which will call all the functions with it's arguments from left to right.
+### Refs
 
-```jsx|pure
-import createChainedFunction from 'rc-util/lib/createChainedFunction';
+| Export                         | Description                                                              |
+| ------------------------------ | ------------------------------------------------------------------------ |
+| `composeRef`, `useComposeRef`  | Merge multiple refs into a single ref callback.                          |
+| `fillRef`                      | Assign a value to callback and object refs.                              |
+| `getNodeRef`                   | Read refs from React elements, including the React 19 `props.ref` shape. |
+| `supportRef`, `supportNodeRef` | Check whether a component or element can receive refs.                   |
+
+### DOM
+
+| Export                                       | Description                                                               |
+| -------------------------------------------- | ------------------------------------------------------------------------- |
+| `canUseDom`                                  | Check whether DOM APIs are available.                                     |
+| `contains`                                   | Check whether one DOM node contains another.                              |
+| `getDOM`, `isDOM`                            | Resolve or test DOM nodes from refs and elements.                         |
+| `getFocusNodeList`, `triggerFocus`           | Find focusable nodes and focus inputs with optional cursor placement.     |
+| `lockFocus`, `useLockFocus`                  | Keep focus inside a container until the lock is released.                 |
+| `injectCSS`, `updateCSS`, `removeCSS`        | Add, update, and remove dynamic style nodes with CSP and prepend support. |
+| `getShadowRoot`                              | Resolve the shadow root for a node.                                       |
+| `isStyleSupport`                             | Check browser style support.                                              |
+| `isVisible`                                  | Check whether a DOM node is visible.                                      |
+| `getScrollBarSize`, `getTargetScrollBarSize` | Measure global or target scrollbar size.                                  |
+
+### React And Data Utilities
+
+| Export                               | Description                                                           |
+| ------------------------------------ | --------------------------------------------------------------------- |
+| `Portal`                             | Render children into a specific container.                            |
+| `render`, `unmount`                  | Compatibility wrappers for rendering and unmounting React roots.      |
+| `toArray`                            | Convert React children to an array with optional keep-empty behavior. |
+| `KeyCode`                            | Keyboard code enum and key event helpers.                             |
+| `get`, `set`, `merge`, `mergeWith`   | Object path and merge helpers.                                        |
+| `isEqual`                            | Equality check with optional shallow compare mode.                    |
+| `mergeProps`                         | Merge React props while composing event handlers.                     |
+| `omit`, `pickAttrs`, `proxyObject`   | Object and DOM attribute helpers.                                     |
+| `raf`                                | RequestAnimationFrame wrapper with cancel support.                    |
+| `isMobile`                           | Runtime mobile detection helper.                                      |
+| `warning`, `noteOnce`, `resetWarned` | Development warnings with once-only helpers.                          |
+
+### Test Helpers
+
+| Export                                        | Description                                            |
+| --------------------------------------------- | ------------------------------------------------------ |
+| `spyElementPrototype`, `spyElementPrototypes` | Temporarily spy on element prototype methods in tests. |
+
+## Development
+
+```bash
+npm install
+npm start
 ```
 
-### deprecated
-
-> (prop: string, instead: string, component: string): void
-
-Log an error message to warn developers that `prop` is deprecated.
-
-```jsx|pure
-import deprecated from 'rc-util/lib/deprecated';
+```bash
+npm test
+npm run tsc
+npm run lint
+npm run compile
+npm run build
 ```
 
-### getContainerRenderMixin
+## Release
 
-> (config: Object): Object
-
-To generate a mixin which will render specific component into specific container automatically.
-
-```jsx|pure
-import getContainerRenderMixin from 'rc-util/lib/getContainerRenderMixin';
+```bash
+npm run prepublishOnly
 ```
 
-Fields in `config` and their meanings.
-
-| Field         | Type                         | Description                                                                | Default |
-| ------------- | ---------------------------- | -------------------------------------------------------------------------- | ------- |
-| autoMount     | boolean                      | Whether to render component into container automatically                   | true    |
-| autoDestroy   | boolean                      | Whether to remove container automatically while the component is unmounted | true    |
-| isVisible     | (instance): boolean          | A function to get current visibility of the component                      | -       |
-| isForceRender | (instance): boolean          | A function to determine whether to render popup even it's not visible      | -       |
-| getComponent  | (instance, extra): ReactNode | A function to get the component which will be rendered into container      | -       |
-| getContainer  | (instance): HTMLElement      | A function to get the container                                            |         |
-
-### Portal
-
-Render children to the specific container;
-
-```jsx|pure
-import Portal from 'rc-util/lib/Portal';
-```
-
-Props:
-
-| Prop         | Type            | Description                     | Default |
-| ------------ | --------------- | ------------------------------- | ------- |
-| children     | ReactChildren   | Content render to the container | -       |
-| getContainer | (): HTMLElement | A function to get the container | -       |
-
-### getScrollBarSize
-
-> (fresh?: boolean): number
-
-Get the width of scrollbar.
-
-```jsx|pure
-import getScrollBarSize from 'rc-util/lib/getScrollBarSize';
-```
-
-### guid
-
-> (): string
-
-To generate a global unique id across current application.
-
-```jsx|pure
-import guid from 'rc-util/lib/guid';
-```
-
-### pickAttrs
-
-> (props: Object): Object
-
-Pick valid HTML attributes and events from props.
-
-```jsx|pure
-import pickAttrs from 'rc-util/lib/pickAttrs';
-```
-
-### warn
-
-> (msg: string): void
-
-A shallow wrapper of `console.warn`.
-
-```jsx|pure
-import warn from 'rc-util/lib/warn';
-```
-
-### warning
-
-> (valid: boolean, msg: string): void
-
-A shallow wrapper of [warning](https://github.com/BerkeleyTrue/warning), but only warning once for the same message.
-
-```jsx|pure
-import warning, { noteOnce } from 'rc-util/lib/warning';
-
-warning(false, '[antd Component] test hello world');
-
-// Low level note
-noteOnce(false, '[antd Component] test hello world');
-```
-
-### Children
-
-A collection of functions to operate React elements' children.
-
-#### Children/mapSelf
-
-> (children): children
-
-Return a shallow copy of children.
-
-```jsx|pure
-import mapSelf from 'rc-util/lib/Children/mapSelf';
-```
-
-#### Children/toArray
-
-> (children: ReactNode[]): ReactNode[]
-
-Convert children into an array.
-
-```jsx|pure
-import toArray from 'rc-util/lib/Children/toArray';
-```
-
-### Dom
-
-A collection of functions to operate DOM elements.
-
-#### Dom/addEventlistener
-
-> (target: ReactNode, eventType: string, listener: Function): { remove: Function }
-
-A shallow wrapper of [add-dom-event-listener](https://github.com/yiminghe/add-dom-event-listener).
-
-```jsx|pure
-import addEventlistener from 'rc-util/lib/Dom/addEventlistener';
-```
-
-#### Dom/canUseDom
-
-> (): boolean
-
-Check if DOM is available.
-
-```jsx|pure
-import canUseDom from 'rc-util/lib/Dom/canUseDom';
-```
-
-#### Dom/class
-
-A collection of functions to operate DOM nodes' class name.
-
-- `hasClass(node: HTMLElement, className: string): boolean`
-- `addClass(node: HTMLElement, className: string): void`
-- `removeClass(node: HTMLElement, className: string): void`
-
-```jsx|pure
-import cssClass from 'rc-util/lib/Dom/class;
-```
-
-#### Dom/contains
-
-> (root: HTMLElement, node: HTMLElement): boolean
-
-Check if node is equal to root or in the subtree of root.
-
-```jsx|pure
-import contains from 'rc-util/lib/Dom/contains';
-```
-
-#### Dom/css
-
-A collection of functions to get or set css styles.
-
-- `get(node: HTMLElement, name?: string): any`
-- `set(node: HTMLElement, name?: string, value: any) | set(node, object)`
-- `getOuterWidth(el: HTMLElement): number`
-- `getOuterHeight(el: HTMLElement): number`
-- `getDocSize(): { width: number, height: number }`
-- `getClientSize(): { width: number, height: number }`
-- `getScroll(): { scrollLeft: number, scrollTop: number }`
-- `getOffset(node: HTMLElement): { left: number, top: number }`
-
-```jsx|pure
-import css from 'rc-util/lib/Dom/css';
-```
-
-#### Dom/focus
-
-A collection of functions to operate focus status of DOM node.
-
-- `saveLastFocusNode(): void`
-- `clearLastFocusNode(): void`
-- `backLastFocusNode(): void`
-- `getFocusNodeList(node: HTMLElement): HTMLElement[]` get a list of focusable nodes from the subtree of node.
-- `limitTabRange(node: HTMLElement, e: Event): void`
-
-```jsx|pure
-import focus from 'rc-util/lib/Dom/focus';
-```
-
-#### Dom/support
-
-> { animation: boolean | Object, transition: boolean | Object }
-
-A flag to tell whether current environment supports `animationend` or `transitionend`.
-
-```jsx|pure
-import support from 'rc-util/lib/Dom/support';
-```
-
-### KeyCode
-
-> Enum
-
-Enum of KeyCode, please check the [definition](https://github.com/react-component/util/blob/master/src/KeyCode.ts) of it.
-
-```jsx|pure
-import KeyCode from 'rc-util/lib/KeyCode';
-```
-
-#### KeyCode.isTextModifyingKeyEvent
-
-> (e: Event): boolean
-
-Whether text and modified key is entered at the same time.
-
-#### KeyCode.isCharacterKey
-
-> (keyCode: KeyCode): boolean
-
-Whether character is entered.
-
-### ScrollLocker
-
-> ScrollLocker<{lock: (options: {container: HTMLElement}) => void, unLock: () => void}>
-
-improve shake when page scroll bar hidden.
-
-`ScrollLocker` change body style, and add a class `ant-scrolling-effect` when called, so if you page look abnormal, please check this;
-
-```js
-import ScrollLocker from 'rc-util/lib/Dom/scrollLocker';
-
-const scrollLocker = new ScrollLocker();
-
-// lock
-scrollLocker.lock()
-
-// unLock
-scrollLocker.unLock()
-```
+The release script compiles the package and runs `rc-np`.
 
 ## License
 
-[MIT](/LICENSE)
+`@rc-component/util` is released under the MIT license.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Then open <http://localhost:8000/>.
 | `useState`                                 | State helper that can ignore updates after destroy.                                                    |
 | `useSyncState`                             | Synchronous state getter and updater pair.                                                             |
 | `useId`, `getId`                           | Stable id helpers.                                                                                     |
-| `useMobile`                                | Mobile environment detection hook.                                                                     |
 
 ### Refs
 

--- a/docs/examples/dynaymicCSS.tsx
+++ b/docs/examples/dynaymicCSS.tsx
@@ -1,5 +1,5 @@
-import type { Prepend } from 'rc-util/es/Dom/dynamicCSS';
-import { removeCSS, updateCSS } from 'rc-util/es/Dom/dynamicCSS';
+import type { Prepend } from '@rc-component/util/es/Dom/dynamicCSS';
+import { removeCSS, updateCSS } from '@rc-component/util/es/Dom/dynamicCSS';
 import React from 'react';
 
 function injectStyle(id: number, prepend?: Prepend, priority?: number) {

--- a/docs/examples/focus.tsx
+++ b/docs/examples/focus.tsx
@@ -1,5 +1,5 @@
+import { useLockFocus } from '@rc-component/util/es/Dom/focus';
 import React, { useRef } from 'react';
-import { useLockFocus } from '../../src/Dom/focus';
 
 export default function FocusDemo() {
   const containerRef = useRef<HTMLDivElement>(null);

--- a/docs/examples/getScrollBarSize.tsx
+++ b/docs/examples/getScrollBarSize.tsx
@@ -1,6 +1,6 @@
 import getScrollBarSize, {
   getTargetScrollBarSize,
-} from 'rc-util/es/getScrollBarSize';
+} from '@rc-component/util/es/getScrollBarSize';
 import React from 'react';
 
 const cssText = `

--- a/docs/examples/portal.tsx
+++ b/docs/examples/portal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PortalWrapper from 'rc-util/es/PortalWrapper';
+import PortalWrapper from '@rc-component/util/es/PortalWrapper';
 
 const Demo: React.FC = () => {
   const divRef = React.useRef<HTMLDivElement>(null);

--- a/docs/examples/styleChecker.tsx
+++ b/docs/examples/styleChecker.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isStyleSupport } from 'rc-util/es/Dom/styleChecker';
+import { isStyleSupport } from '@rc-component/util/es/Dom/styleChecker';
 
 export default () => {
   const supportFlex = isStyleSupport('flex');

--- a/docs/examples/toArray.tsx
+++ b/docs/examples/toArray.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import toArray, { type Option } from 'rc-util/es/Children/toArray';
+import toArray, { type Option } from '@rc-component/util/es/Children/toArray';
 
 const initialState = {
   'no-children': false,
@@ -8,45 +8,56 @@ const initialState = {
   'nested-children': false,
   'array-of-children': false,
   'is-falsy': false,
-  'fragment': false,
-} as const
+  fragment: false,
+} as const;
 
-type Action = keyof typeof initialState
+type Action = keyof typeof initialState;
 
-const Wrapper = ({ children, ...options }: { children?: React.ReactNode } & Option) => {
+const Wrapper = ({
+  children,
+  ...options
+}: { children?: React.ReactNode } & Option) => {
   window.console.log(toArray(children, options));
 
   return children as any;
 };
 
-const DemoBox = React.memo(({ children, name }: { children?: any, name: Action }) => {
-  const [keepEmpty, setkeepEmpty] = React.useState(false);
-  const [show, setShow] = React.useState(false)
-  return (
-    <React.Fragment key={name}>
-      <label style={{ display: 'inline-block', width: 180 }}>
-        <input type="checkbox" checked={show} onChange={() => setShow(prev => !prev)} />
-        {name}
-      </label>
-      <label>
-        <input
-          type="checkbox"
-          checked={keepEmpty}
-          onChange={() => setkeepEmpty(prev => !prev)}
-          disabled={!show}
-        />
-        keepEmpty={keepEmpty ? 'true' : 'false'}
-      </label>
-      <br />
-      {show && React.cloneElement<any>(children, { keepEmpty })}
-      <br />
-    </React.Fragment>
-  )
-})
+const DemoBox = React.memo(
+  ({ children, name }: { children?: any; name: Action }) => {
+    const [keepEmpty, setkeepEmpty] = React.useState(false);
+    const [show, setShow] = React.useState(false);
+    return (
+      <React.Fragment key={name}>
+        <label style={{ display: 'inline-block', width: 180 }}>
+          <input
+            type="checkbox"
+            checked={show}
+            onChange={() => setShow(prev => !prev)}
+          />
+          {name}
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={keepEmpty}
+            onChange={() => setkeepEmpty(prev => !prev)}
+            disabled={!show}
+          />
+          keepEmpty={keepEmpty ? 'true' : 'false'}
+        </label>
+        <br />
+        {show && React.cloneElement<any>(children, { keepEmpty })}
+        <br />
+      </React.Fragment>
+    );
+  },
+);
 
 const App = () => (
   <>
-    <p onClick={window.console.clear}>Press F12 to open the console (Click Clear Console)</p>
+    <p onClick={window.console.clear}>
+      Press F12 to open the console (Click Clear Console)
+    </p>
 
     <DemoBox name="no-children">
       <Wrapper />
@@ -59,42 +70,42 @@ const App = () => (
     </DemoBox>
 
     <DemoBox name="multiple-children">
-      <Wrapper >
+      <Wrapper>
         <p>1</p>
         <span>2</span>
       </Wrapper>
     </DemoBox>
 
     <DemoBox name="nested-children">
-      <Wrapper >
+      <Wrapper>
         <ul>
-          {Array.from({ length: 5 }, (_, i) => <li key={i}>{i}</li>)}
+          {Array.from({ length: 5 }, (_, i) => (
+            <li key={i}>{i}</li>
+          ))}
         </ul>
       </Wrapper>
     </DemoBox>
 
     <DemoBox name="array-of-children">
-      <Wrapper >
-        {
+      <Wrapper>
+        {[
           [
             [
-              [
-                <span key="1">111</span>,
-                <span key="2">222</span>,
-                <span key="3">333</span>
-              ],
-              <span key="4">444</span>,
-              <span key="5">555</span>
+              <span key="1">111</span>,
+              <span key="2">222</span>,
+              <span key="3">333</span>,
             ],
-            <span key="6">666</span>,
-            <span key="7">777</span>
-          ]
-        }
+            <span key="4">444</span>,
+            <span key="5">555</span>,
+          ],
+          <span key="6">666</span>,
+          <span key="7">777</span>,
+        ]}
       </Wrapper>
     </DemoBox>
 
     <DemoBox name="is-falsy">
-      <Wrapper >
+      <Wrapper>
         {null}
         {undefined}
         {false}
@@ -106,18 +117,16 @@ const App = () => (
     </DemoBox>
 
     <DemoBox name="fragment">
-      <Wrapper >
+      <Wrapper>
         <React.Fragment />
-        <React.Fragment >A</React.Fragment>
-        <React.Fragment >
+        <React.Fragment>A</React.Fragment>
+        <React.Fragment>
           <React.Fragment />
-          <React.Fragment >B</React.Fragment>
+          <React.Fragment>B</React.Fragment>
         </React.Fragment>
       </Wrapper>
     </DemoBox>
   </>
 );
-
-
 
 export default App;

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 hero:
-  title: rc-util
-  description: Common Utils For React Component
+  title: '@rc-component/util'
+  description: Common React utilities shared across rc-component packages
 ---
 
 <embed src="../README.md"></embed>

--- a/package.json
+++ b/package.json
@@ -25,17 +25,16 @@
     "build": "dumi build",
     "compile": "father build",
     "coverage": "npm test -- --coverage",
-    "lint": "eslint src/ --ext .tsx,.ts & eslint tests/ --ext .tsx,.ts",
+    "lint": "eslint src/ tests/ --ext .tsx,.ts",
     "prepare": "husky install",
     "prepublishOnly": "npm run compile && rc-np",
+    "prettier": "prettier --write --ignore-unknown .",
     "start": "dumi dev",
-    "test": "rc-test"
+    "test": "rc-test",
+    "tsc": "tsc --noEmit"
   },
   "lint-staged": {
-    "**/*.{js,jsx,tsx,ts,md,json}": [
-      "prettier --write",
-      "git add"
-    ]
+    "**/*.{js,jsx,tsx,ts,md,json}": "prettier --write --ignore-unknown"
   },
   "dependencies": {
     "is-mobile": "^5.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,11 @@
     "esModuleInterop": true,
     "paths": {
       "@/*": ["src/*"],
-      "@@/*": ["src/.dumi/*"],
+      "@@/*": [".dumi/tmp/*"],
+      "@rc-component/util": ["src/index.ts"],
       "rc-util": ["src/index.ts"],
       "rc-util/es/*": ["src/*"]
     }
-  }
+  },
+  "include": [".dumirc.ts", ".fatherrc.ts", "docs", "src", "tests"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,7 @@
       "@/*": ["src/*"],
       "@@/*": [".dumi/tmp/*"],
       "@rc-component/util": ["src/index.ts"],
-      "rc-util": ["src/index.ts"],
-      "rc-util/es/*": ["src/*"]
+      "@rc-component/util/es/*": ["src/*"]
     }
   },
   "include": [".dumirc.ts", ".fatherrc.ts", "docs", "src", "tests"]

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": "umijs",
+  "installCommand": "npm install",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".doc"
+}


### PR DESCRIPTION
## 变更

- 按 ant-design/ant-design#58514 的统一标准重写 README，切换到 `@rc-component/util` 标题、scoped npm 徽章、Ant Design 生态说明、Highlights、Install、Usage、Examples、API、Development、Release 和 License 结构。
- 补充 rc-util 当前导出的 hooks、ref、DOM、React/data/test helper API 摘要，移除 README 中已经不符合当前源码的旧 `rc-util` API 文档。
- 标准化脚本：新增 `tsc` 和 `prettier`，修正 `lint` 为单条 eslint 命令，更新 lint-staged 的 Prettier 写法。
- 将主测试 workflow 切换到 `react-component/rc-test/.github/workflows/test-utoo.yml@main`。
- 新增 React Doctor、Surge Preview、可选 Cloudflare Pages Preview、Vercel 配置和 Funding 配置。
- 更新 CodeQL、checkout、setup-node、gh-pages 等 action 到已 pin 的 SHA，并禁用 checkout 的 persisted credentials。
- 补充 tsconfig include 和 `@rc-component/util` path，更新 docs 首页标题。

## 兼容性

- 无运行时代码变更。
- 不引入 breaking change。
- 预览和发布构建继续使用现有 dumi 输出目录 `.doc`。

## 验证

- `npx prettier --write --ignore-unknown README.md package.json tsconfig.json docs/index.md vercel.json .github/FUNDING.yml .github/workflows/*.yml`
- `npm run tsc`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run compile`
- `npm run build`
- `git diff --check`

说明：`npm run lint` 和 `npm run compile` 仍有两个既有 warning（`findDOMNode.ts` 的 type import、`Portal.tsx` 的 `{}` 类型），没有新增 error。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 新增 PR 预览部署支持，可自动生成在线预览。
  * 增加站点托管与预览配置，便于更快查看变更效果。

* **Documentation**
  * 重写首页与 README 内容，更新品牌、简介、安装与用法说明。
  * 同步更新多个示例页面的引用与展示内容。

* **Chores**
  * 更新 CI/安全检查流程与依赖版本锁定，提升构建稳定性。
  * 调整项目别名与脚本配置，保持开发与发布流程一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->