### PR TITLE
fix(pickAttrs): forward missing DOM event handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ bun.lockb
 es
 docs-dist
 .vercel
+.vscode

--- a/src/pickAttrs.ts
+++ b/src/pickAttrs.ts
@@ -19,8 +19,10 @@ const eventsName = `onCopy onCut onPaste onCompositionEnd onCompositionStart onC
     onDurationChange onEmptied onEncrypted onEnded onError onLoadedData onLoadedMetadata
     onLoadStart onPause onPlay onPlaying onProgress onRateChange onSeeked onSeeking onStalled onSuspend onTimeUpdate onVolumeChange onWaiting onLoad
     onPointerDown onPointerMove onPointerUp onPointerCancel onPointerEnter onPointerLeave onPointerOver onPointerOut onGotPointerCapture onLostPointerCapture
-    onAnimationStart onAnimationEnd onAnimationIteration onTransitionEnd
-    onBeforeInput onReset onInvalid`;
+    onAnimationStart onAnimationEnd onAnimationIteration
+    onTransitionEnd onTransitionRun onTransitionStart onTransitionCancel
+    onBeforeInput onReset onInvalid
+    onAuxClick onToggle onBeforeToggle onCancel onClose onResize onScrollEnd`;
 
 const propList = `${attributes} ${eventsName}`.split(/[\s\n]+/);
 

--- a/src/pickAttrs.ts
+++ b/src/pickAttrs.ts
@@ -17,7 +17,10 @@ const eventsName = `onCopy onCut onPaste onCompositionEnd onCompositionStart onC
     onMouseEnter onMouseLeave onMouseMove onMouseOut onMouseOver onMouseUp onSelect onTouchCancel
     onTouchEnd onTouchMove onTouchStart onScroll onWheel onAbort onCanPlay onCanPlayThrough
     onDurationChange onEmptied onEncrypted onEnded onError onLoadedData onLoadedMetadata
-    onLoadStart onPause onPlay onPlaying onProgress onRateChange onSeeked onSeeking onStalled onSuspend onTimeUpdate onVolumeChange onWaiting onLoad onError`;
+    onLoadStart onPause onPlay onPlaying onProgress onRateChange onSeeked onSeeking onStalled onSuspend onTimeUpdate onVolumeChange onWaiting onLoad
+    onPointerDown onPointerMove onPointerUp onPointerCancel onPointerEnter onPointerLeave onPointerOver onPointerOut onGotPointerCapture onLostPointerCapture
+    onAnimationStart onAnimationEnd onAnimationIteration onTransitionEnd
+    onBeforeInput onReset onInvalid`;
 
 const propList = `${attributes} ${eventsName}`.split(/[\s\n]+/);
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -295,6 +295,7 @@ describe('utils', () => {
       onAnimationEnd: null,
       onTransitionEnd: null,
       onInvalid: null,
+      onToggle: null,
       checked: true,
       'data-my': 1,
       'aria-this': 2,
@@ -309,6 +310,7 @@ describe('utils', () => {
         onAnimationEnd: null,
         onTransitionEnd: null,
         onInvalid: null,
+        onToggle: null,
         checked: true,
         'data-my': 1,
         'aria-this': 2,
@@ -330,6 +332,7 @@ describe('utils', () => {
         onAnimationEnd: null,
         onTransitionEnd: null,
         onInvalid: null,
+        onToggle: null,
         checked: true,
         role: 'button',
       });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import pickAttrs from '../src/pickAttrs';
 import get from '../src/utils/get';
 import set, { mergeWith, merge } from '../src/utils/set';
@@ -291,11 +293,6 @@ describe('utils', () => {
   describe('pickAttrs', () => {
     const originProps = {
       onClick: null,
-      onPointerDown: null,
-      onAnimationEnd: null,
-      onTransitionEnd: null,
-      onInvalid: null,
-      onToggle: null,
       checked: true,
       'data-my': 1,
       'aria-this': 2,
@@ -306,11 +303,6 @@ describe('utils', () => {
     it('default', () => {
       expect(pickAttrs(originProps)).toEqual({
         onClick: null,
-        onPointerDown: null,
-        onAnimationEnd: null,
-        onTransitionEnd: null,
-        onInvalid: null,
-        onToggle: null,
         checked: true,
         'data-my': 1,
         'aria-this': 2,
@@ -328,11 +320,6 @@ describe('utils', () => {
     it('attr only', () => {
       expect(pickAttrs(originProps, { attr: true })).toEqual({
         onClick: null,
-        onPointerDown: null,
-        onAnimationEnd: null,
-        onTransitionEnd: null,
-        onInvalid: null,
-        onToggle: null,
         checked: true,
         role: 'button',
       });
@@ -344,6 +331,40 @@ describe('utils', () => {
         'aria-this': 2,
         role: 'button',
       });
+    });
+
+    it('eventsName stays in full sync with @types/react', () => {
+      const dts = fs.readFileSync(
+        path.join(
+          path.dirname(require.resolve('@types/react/package.json')),
+          'index.d.ts',
+        ),
+        'utf8',
+      );
+
+      const isCapturePhase = (n: string) =>
+        n.endsWith('Capture') && !/^on(Got|Lost)PointerCapture$/.test(n);
+      const reactEvents = new Set(
+        [...dts.matchAll(/\bon[A-Z]\w*(?=\?:)/g)]
+          .map(m => m[0])
+          .filter(n => !isCapturePhase(n)),
+      );
+
+      const src = fs.readFileSync(
+        path.join(__dirname, '../src/pickAttrs.ts'),
+        'utf8',
+      );
+      const ourEvents = new Set(
+        src
+          .match(/const eventsName = `([\s\S]+?)`/)![1]
+          .split(/\s+/)
+          .filter(Boolean),
+      );
+
+      expect({
+        missing: [...reactEvents].filter(e => !ourEvents.has(e)), // React has, we dropped
+        stale: [...ourEvents].filter(e => !reactEvents.has(e)), //  we have, React removed
+      }).toEqual({ missing: [], stale: [] });
     });
   });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -291,6 +291,10 @@ describe('utils', () => {
   describe('pickAttrs', () => {
     const originProps = {
       onClick: null,
+      onPointerDown: null,
+      onAnimationEnd: null,
+      onTransitionEnd: null,
+      onInvalid: null,
       checked: true,
       'data-my': 1,
       'aria-this': 2,
@@ -301,6 +305,10 @@ describe('utils', () => {
     it('default', () => {
       expect(pickAttrs(originProps)).toEqual({
         onClick: null,
+        onPointerDown: null,
+        onAnimationEnd: null,
+        onTransitionEnd: null,
+        onInvalid: null,
         checked: true,
         'data-my': 1,
         'aria-this': 2,
@@ -318,6 +326,10 @@ describe('utils', () => {
     it('attr only', () => {
       expect(pickAttrs(originProps, { attr: true })).toEqual({
         onClick: null,
+        onPointerDown: null,
+        onAnimationEnd: null,
+        onTransitionEnd: null,
+        onInvalid: null,
         checked: true,
         role: 'button',
       });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
 import pickAttrs from '../src/pickAttrs';
 import get from '../src/utils/get';
 import set, { mergeWith, merge } from '../src/utils/set';
@@ -333,10 +333,10 @@ describe('utils', () => {
       });
     });
 
-    it('eventsName stays in full sync with @types/react', () => {
-      const dts = fs.readFileSync(
-        path.join(
-          path.dirname(require.resolve('@types/react/package.json')),
+    it('forwards every React DOM event handler', () => {
+      const dts = readFileSync(
+        join(
+          dirname(require.resolve('@types/react/package.json')),
           'index.d.ts',
         ),
         'utf8',
@@ -344,27 +344,14 @@ describe('utils', () => {
 
       const isCapturePhase = (n: string) =>
         n.endsWith('Capture') && !/^on(Got|Lost)PointerCapture$/.test(n);
-      const reactEvents = new Set(
-        [...dts.matchAll(/\bon[A-Z]\w*(?=\?:)/g)]
-          .map(m => m[0])
-          .filter(n => !isCapturePhase(n)),
-      );
+      const reactEvents = [...dts.matchAll(/\bon[A-Z]\w*(?=\?:)/g)]
+        .map(m => m[0])
+        .filter(n => !isCapturePhase(n));
 
-      const src = fs.readFileSync(
-        path.join(__dirname, '../src/pickAttrs.ts'),
-        'utf8',
+      const dropped = reactEvents.filter(
+        e => pickAttrs({ [e]: 1 }, { attr: true })[e] === undefined,
       );
-      const ourEvents = new Set(
-        src
-          .match(/const eventsName = `([\s\S]+?)`/)![1]
-          .split(/\s+/)
-          .filter(Boolean),
-      );
-
-      expect({
-        missing: [...reactEvents].filter(e => !ourEvents.has(e)), // React has, we dropped
-        stale: [...ourEvents].filter(e => !reactEvents.has(e)), //  we have, React removed
-      }).toEqual({ missing: [], stale: [] });
+      expect(dropped).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary

`pickAttrs`'s event allowlist (`eventsName`) was missing many React DOM event handlers, so those handlers were silently dropped when picked props were spread onto a DOM node.

Completed the list so it fully matches React's `DOMAttributes` (all non-capture `on*` handlers):

- **Pointer**: `onPointerDown` `onPointerMove` `onPointerUp` `onPointerCancel` `onPointerEnter` `onPointerLeave` `onPointerOver` `onPointerOut` `onGotPointerCapture` `onLostPointerCapture`
- **Animation**: `onAnimationStart` `onAnimationEnd` `onAnimationIteration`
- **Transition**: `onTransitionEnd` `onTransitionRun` `onTransitionStart` `onTransitionCancel`
- **Form**: `onBeforeInput` `onReset` `onInvalid`
- **Dialog / details / popover**: `onToggle` `onBeforeToggle` `onCancel` `onClose`
- **Misc**: `onAuxClick` `onResize` `onScrollEnd`

Also removed a duplicate `onError` entry (harmless — `propList` is matched with `.includes()` — but redundant).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 扩展支持的事件属性范围，涵盖加载、指针、动画、过渡及输入/表单相关事件。
  - 提升事件属性筛选的兼容性，减少有效事件被遗漏的情况。

- **维护**
  - 忽略编辑器配置目录，避免相关文件被纳入版本管理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
