### PR TITLE
ci: fix react-doctor workflow (bump action, drop phantom input)

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -20,5 +20,3 @@ jobs:
         with:
           persist-credentials: false
       - uses: millionco/react-doctor@0b4f4f4bd248a154e64eb508a48347f71154b3f3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: millionco/react-doctor@0b4f4f4bd248a154e64eb508a48347f71154b3f3
+      - uses: millionco/react-doctor@964622bf15fa5f8eef7e05196407aa08dc779087 # v2.2.7


### PR DESCRIPTION
修一下红了的 ci，以及就是我感觉这个 vercel deploy 对 util 这种工具 lib 来说没必要，社区的 pr ci 不能全绿强迫症有点难受

<img width="1788" height="978" alt="image" src="https://github.com/user-attachments/assets/1575217a-15e7-4d90-bd0c-4204b9458630" />

Two fixes to `.github/workflows/react-doctor.yml`.

## 1. Bump the pinned action `v2.2.2` → `v2.2.7` (fixes the failing check)

## 2. Drop the unsupported `github-token` input

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **其他**
  * 更新 React Doctor 检查工具至 v2.2.7，提升持续集成检查的稳定性。
  * 简化检查步骤配置，保持现有工作流行为不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->