### PR TITLE
feat: add common value guard utilities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export {
   getTargetScrollBarSize,
 } from './getScrollBarSize';
 export { default as isEqual } from './isEqual';
+export { isNonNullable, isReactRenderable } from './is';
 export { default as isMobile } from './isMobile';
 export { default as omit } from './omit';
 export { default as pickAttrs } from './pickAttrs';

--- a/src/is.ts
+++ b/src/is.ts
@@ -6,7 +6,13 @@ export function isNonNullable<T>(value: T): value is NonNullable<T> {
 }
 
 /**
- * Check if a value can produce renderable React content.
+ * Check whether a value should be treated as renderable content.
+ *
+ * Returns `false` only for `null`, `undefined`, `false`, and `''`; all other
+ * values, including `0` and `true`, are treated as renderable.
+ *
+ * This is a compatibility-oriented presence check, not a complete React node
+ * validator.
  */
 export function isReactRenderable<T>(
   value: T,

--- a/src/is.ts
+++ b/src/is.ts
@@ -1,0 +1,15 @@
+/**
+ * Check if a value is neither `null` nor `undefined`.
+ */
+export function isNonNullable<T>(value: T): value is NonNullable<T> {
+  return value !== undefined && value !== null;
+}
+
+/**
+ * Check if a value can produce renderable React content.
+ */
+export function isReactRenderable<T>(
+  value: T,
+): value is Exclude<NonNullable<T>, false | ''> {
+  return isNonNullable(value) && value !== false && value !== '';
+}

--- a/tests/is.test.tsx
+++ b/tests/is.test.tsx
@@ -1,0 +1,32 @@
+import { isNonNullable, isReactRenderable } from '../src';
+
+describe('is', () => {
+  describe('isNonNullable', () => {
+    it.each([undefined, null])('returns false for nullable value %p', value => {
+      expect(isNonNullable(value)).toBeFalsy();
+    });
+
+    it.each([false, '', 0, 'text', <span key="node" />])(
+      'returns true for non-nullable value %p',
+      value => {
+        expect(isNonNullable(value)).toBeTruthy();
+      },
+    );
+  });
+
+  describe('isReactRenderable', () => {
+    it.each([undefined, null, false, ''])(
+      'returns false for non-renderable value %p',
+      value => {
+        expect(isReactRenderable(value)).toBeFalsy();
+      },
+    );
+
+    it.each([0, true, 'text', <span key="node" />])(
+      'returns true for renderable value %p',
+      value => {
+        expect(isReactRenderable(value)).toBeTruthy();
+      },
+    );
+  });
+});


### PR DESCRIPTION
## 变更说明

- 新增 isNonNullable 类型守卫，用于排除 null 和 undefined。
- 新增 isReactRenderable 类型守卫，用于识别可参与 React 渲染的有效值。
- 从包入口统一导出两个工具函数，并支持 is 子路径导入。
- 补充空值、布尔值、字符串、数字和 React 元素的边界测试。

## 验证

- npm test -- --runInBand
- npm run tsc
- ESLint 与 Prettier 检查
- npm run compile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 `isNonNullable` 工具，用于判断值是否不为 `null` 或 `undefined`。
  * 新增 `isReactRenderable` 工具，用于判断内容是否可渲染为 React 内容。
  * 公开导出上述两个工具，便于使用。

* **测试**
  * 为两项工具补充了涵盖常见值和 React 元素的测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->