### PR TITLE
fix: avoid TrustedHTML sink for style injection

### DIFF
--- a/src/Dom/dynamicCSS.ts
+++ b/src/Dom/dynamicCSS.ts
@@ -76,7 +76,7 @@ export function injectCSS(css: string, option: Options = {}) {
   if (csp?.nonce) {
     styleNode.nonce = csp?.nonce;
   }
-  styleNode.innerHTML = css;
+  styleNode.textContent = css;
 
   const container = getContainer(option);
   const { firstChild } = container;
@@ -177,8 +177,8 @@ export function updateCSS(
       existNode.nonce = option.csp?.nonce;
     }
 
-    if (existNode.innerHTML !== css) {
-      existNode.innerHTML = css;
+    if (existNode.textContent !== css) {
+      existNode.textContent = css;
     }
 
     return existNode;

--- a/tests/dynamicCSS.test.tsx
+++ b/tests/dynamicCSS.test.tsx
@@ -34,6 +34,41 @@ describe('dynamicCSS', () => {
       expect(document.querySelector('style').nonce).toEqual('light');
     });
 
+    it('does not assign CSS through the innerHTML sink', () => {
+      const innerHTMLDescriptor = Object.getOwnPropertyDescriptor(
+        HTMLStyleElement.prototype,
+        'innerHTML',
+      );
+
+      Object.defineProperty(HTMLStyleElement.prototype, 'innerHTML', {
+        configurable: true,
+        set() {
+          throw new TypeError(
+            "This document requires 'TrustedHTML' assignment.",
+          );
+        },
+      });
+
+      try {
+        const style = injectCSS(TEST_STYLE);
+        const managedStyle = updateCSS(TEST_STYLE, 'trusted-types');
+
+        expect(style.textContent).toEqual(TEST_STYLE);
+        expect(() => updateCSS('.light {}', 'trusted-types')).not.toThrow();
+        expect(managedStyle.textContent).toEqual('.light {}');
+      } finally {
+        if (innerHTMLDescriptor) {
+          Object.defineProperty(
+            HTMLStyleElement.prototype,
+            'innerHTML',
+            innerHTMLDescriptor,
+          );
+        } else {
+          delete HTMLStyleElement.prototype.innerHTML;
+        }
+      }
+    });
+
     describe('prepend', () => {
       function testPrepend() {
         const head = document.querySelector('head');


### PR DESCRIPTION
Fixes #555.

## Problem

`injectCSS` and the existing-node path in `updateCSS` assign CSS through `HTMLStyleElement.innerHTML`. Under an enforced Trusted Types policy, that is an HTML injection sink and throws `TypeError: This document requires 'TrustedHTML' assignment`, preventing Ant Design styles from being installed.

## Change

- Write and compare style contents through `textContent` instead. CSS is plain text, so this preserves the supplied stylesheet without invoking the HTML parser or requiring a TrustedHTML policy.
- Add a regression that makes the style `innerHTML` setter throw, then covers both initial injection and updating an existing managed style.

## Verification

- Before the source change, the new focused test failed at `injectCSS` with the reported TrustedHTML error.
- Focused dynamicCSS suite: 13/13 passed.
- Full suite: 29 suites passed; 183 tests passed, 1 existing skip.
- `npm run tsc`: passed.
- `npm run compile`: passed.
- `npm run lint`: 0 errors (13 existing unused-disable warnings).
- Prettier and `git diff --check`: passed.

I checked all current open PR changed files. #496 touches the nonce assignment in the same module but leaves `innerHTML` unchanged and addresses a separate CSP report; there is no open PR implementing this Trusted Types fix.

AI assistance disclosure: Codex was used to trace the current sink, build the fail-before/pass-after regression, run validation, audit open PR overlap, and draft this description. I verified the behavior and exact diff locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进动态样式注入与更新，增强对严格内容安全策略环境的兼容性。
  * CSS 内容将按纯文本处理，避免因 HTML 内容限制导致样式应用失败。

* **Tests**
  * 新增相关测试，验证样式在受限环境下仍能正确注入和更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->