### PR TITLE
fix: forward writes through proxyObject

### DIFF
--- a/src/proxyObject.ts
+++ b/src/proxyObject.ts
@@ -18,6 +18,9 @@ export default function proxyObject<
           ? originProp.bind(target)
           : originProp;
       },
+      set(target, prop, value) {
+        return Reflect.set(target, prop, value, target);
+      },
     }) as Obj & ExtendObj;
   }
 

--- a/tests/proxyObject.test.ts
+++ b/tests/proxyObject.test.ts
@@ -20,4 +20,42 @@ describe('proxyObject', () => {
 
     expect(proxyA).toBe(null);
   });
+
+  it('uses the native element as the receiver for property setters', () => {
+    const input = document.createElement('input');
+    const valueDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value',
+    );
+
+    Object.defineProperty(input, 'value', {
+      configurable: true,
+      get() {
+        return valueDescriptor.get.call(this);
+      },
+      set(value: string) {
+        if (this !== input) {
+          throw new TypeError('Illegal invocation');
+        }
+        valueDescriptor.set.call(input, value);
+      },
+    });
+
+    const proxyInput = proxyObject(input, {});
+
+    expect(() => {
+      proxyInput.value = '321';
+    }).not.toThrow();
+    expect(input.value).toBe('321');
+  });
+
+  it('preserves writes to ordinary properties', () => {
+    const div = document.createElement('div');
+    const proxyDiv = proxyObject(div, {});
+
+    expect(() => {
+      proxyDiv.id = 'updated';
+    }).not.toThrow();
+    expect(div.id).toBe('updated');
+  });
 });


### PR DESCRIPTION
## Summary

- forward Proxy writes with the wrapped object as the receiver
- preserve native DOM setter brand checks and ordinary property assignment semantics
- cover both a receiver-sensitive input setter and a normal DOM property write

Closes #546. Also addresses react-component/input-number#684.

## Root cause

`proxyObject` binds reads to the wrapped object, but previously left writes to the Proxy default. When React installs its tracked `value` setter, the nested native setter consequently receives the Proxy rather than the real input and Chrome throws `TypeError: Illegal invocation`.

`Reflect.set(target, prop, value, target)` keeps the normal property descriptor behavior while supplying the real object as the setter receiver. It applies to all properties without converting values or maintaining a DOM-property whitelist.

## Exact-base and overlap evidence

- current master `d1045f4`: the receiver-sensitive regression fails with `TypeError: Illegal invocation`
- real Chrome 151: the current path reports `TypeError:Illegal invocation`; the fixed trap reports `ok:321`
- #547 exact head `009b42a`: the `value` special case works, but `proxyDiv.id = "updated"` throws because its `set` trap returns falsy for every other property
- all open rc-util changed-file lists were checked; #547 is the only overlapping PR and its exact-head limitation is documented in a public review

## Verification

- `npm test -- --runInBand`: 29 suites passed; 184 passed, 1 skipped
- `npm run tsc`: passed
- `npm run lint`: 0 errors, 13 existing unused-disable warnings
- `git diff --check`: passed

## AI assistance disclosure

Codex was used to trace the Proxy receiver behavior, audit overlapping work, implement the regression, run the exact-head and real-Chrome probes, and draft this description. All reported results were executed locally against the cited commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复代理对象设置属性时的行为，确保原生元素能够正确接收属性写入。
  * 修复自定义属性 setter 的调用上下文问题，避免触发非法调用错误。
  * 普通属性（如 `id`）的修改现在会正确保留并同步到目标元素。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->